### PR TITLE
Add custom table assertions

### DIFF
--- a/luatest/luaunit.lua
+++ b/luatest/luaunit.lua
@@ -1761,6 +1761,51 @@ function M.assertNotIsMinusZero(value, extra_msg_or_nil)
 end
 
 ----------------------------------------------------------------
+--                     Custom assertions
+----------------------------------------------------------------
+
+function M.assert_table_has_key(tbl, key, extra_msg_or_nil)
+    M.assert_is_table(tbl)
+    M.assert_is_string(key)
+
+    if tbl[key] == nil then
+        fail_fmt(2, extra_msg_or_nil,
+            "expected %s to have key %s", prettystr(tbl), prettystr(key))
+    end
+end
+
+function M.assert_table_has_keys(tbl, ...)
+    M.assert_is_table(tbl)
+
+    local n = select('#', ...)
+    for i = 1,n do
+        local key = select(i, ...)
+        M.assert_table_has_key(tbl, key)
+    end
+end
+
+function M.assert_table_has_pair(tbl, key, value, extra_msg_or_nil)
+    M.assert_is_table(tbl)
+    M.assert_is_string(key)
+    M.assert_not_is_nil(value)
+
+    if tbl[key] ~= value then
+        fail_fmt(2, extra_msg_or_nil,
+            "expected %s to have key-value pair %s",
+            prettystr(tbl), prettystr({ [key] = value }))
+    end
+end
+
+function M.assert_table_to_include(tbl, inclusion, extra_msg_or_nil)
+    M.assert_is_table(tbl)
+    M.assert_is_table(inclusion)
+
+    for key, value in pairs(inclusion) do
+        M.assert_table_has_pair(tbl, key, value, extra_msg_or_nil)
+    end
+end
+
+----------------------------------------------------------------
 --                     Compatibility layer
 ----------------------------------------------------------------
 

--- a/test/asserts_test.lua
+++ b/test/asserts_test.lua
@@ -1,0 +1,45 @@
+local t = require('luatest')
+local g = t.group('asserts')
+
+g.test_assert_table_has_key = function()
+	t.assert_table_has_key({ a = 'b' }, 'a')
+
+	local ok, err = pcall(t.assert_table_has_key, { 'a', 'b', 'c' }, 2)
+	t.assert_eval_to_false(ok)
+	t.assert_str_contains(err, 'expected: a string value, actual: type number')
+
+	ok, err = pcall(t.assert_table_has_key, { 'a', 'b', 'c' }, 'd')
+	t.assert_eval_to_false(ok)
+	t.assert_str_contains(err, 'expected {"a", "b", "c"} to have key "d"')
+end
+
+g.test_assert_table_has_keys = function()
+	local value = { foo = 'bar', bar = 'buzz' }
+	t.assert_table_has_keys(value, 'foo', 'bar')
+
+	local ok, err = pcall(t.assert_table_has_keys, value, 'buzz')
+	t.assert_eval_to_false(ok)
+	t.assert_str_contains(err, 'expected {bar="buzz", foo="bar"} to have key "buzz"')
+end
+
+g.test_assert_table_has_pair = function()
+	local value = { foo = 'bar', bar = 'buzz' }
+	t.assert_table_has_pair(value, 'bar', 'buzz')
+
+	local ok, err = pcall(t.assert_table_has_pair, value, 'foo', 'buzz')
+	t.assert_eval_to_false(ok)
+	t.assert_str_contains(err,
+		'expected {bar="buzz", foo="bar"} to have key-value pair {foo="buzz"}')
+end
+
+g.test_assert_table_to_include = function()
+	local value = { foo = 'bar', bar = 'buzz' }
+	t.assert_table_to_include(value, { foo = 'bar' })
+	t.assert_table_to_include(value, { foo = 'bar', bar = 'buzz' })
+
+	local ok, err = pcall(t.assert_table_to_include,
+		value, { foo = 'bar', bar = 'buzz', buzz = 'foo' })
+	t.assert_eval_to_false(ok)
+	t.assert_str_contains(err,
+		'expected {bar="buzz", foo="bar"} to have key-value pair {buzz="foo"}')
+end


### PR DESCRIPTION
This patch add several custom assertions which are intended to make table
checks more readable:

```
assert_table_has_key(tbl, key, extra_msg_or_nil)
assert_table_has_keys(tbl, ...)
assert_table_has_pair(tbl, key, value, extra_msg_or_nil)
assert_table_to_include(tbl, inclusion, extra_msg_or_nil)
```

```bash
$ bin/luatest -v asserts
Started on Wed Oct  2 21:54:53 2019
    asserts.test_assert_table_has_key ... Ok
    asserts.test_assert_table_has_keys ... Ok
    asserts.test_assert_table_has_pair ... Ok
    asserts.test_assert_table_to_include ... Ok
=========================================================
Ran 4 tests in 0.001 seconds, 4 successes, 0 failures
OK
```