### PR TITLE
Fix error messages for *_covers matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix not working `--exclude`, `--pattern` options
+- Fix error messages for `*_covers` matchers
 
 # 0.3.0
 

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -28,30 +28,6 @@ luatest.assert = luatest.assert_eval_to_true
 -- @string[opt] message
 luatest.assert_not = luatest.assert_eval_to_false
 
---- Checks that map contains the other one.
--- @tab actual
--- @tab expected
--- @string[opt] message
-function luatest.assert_covers(actual, expected, message)
-    local sliced = {}
-    for k, _ in pairs(expected) do
-        sliced[k] = actual[k]
-    end
-    luatest.assert_equals(sliced, expected, message)
-end
-
---- Checks that map does not contain the other one.
--- @tab actual
--- @tab expected
--- @string[opt] message
-function luatest.assert_not_covers(actual, expected, message)
-    local sliced = {}
-    for k, _ in pairs(expected) do
-        sliced[k] = actual[k]
-    end
-    luatest.assert_not_equals(sliced, expected, message)
-end
-
 return luatest
 
 --- Add before suite hook.
@@ -80,6 +56,13 @@ return luatest
 -- @number actual
 -- @number expected
 -- @number margin
+-- @string[opt] message
+
+--- Checks that map contains the other one.
+--
+-- @function assert_covers
+-- @tab actual
+-- @tab expected
 -- @string[opt] message
 
 --- Check that two values are equal.
@@ -170,6 +153,13 @@ return luatest
 -- @number actual
 -- @number expected
 -- @number margin
+-- @string[opt] message
+
+--- Checks that map does not contain the other one.
+--
+-- @function assert_not_covers
+-- @tab actual
+-- @tab expected
 -- @string[opt] message
 
 --- Check that two values are not equal.

--- a/luatest/luaunit.lua
+++ b/luatest/luaunit.lua
@@ -1250,6 +1250,31 @@ function M.assert_items_equals(actual, expected, extra_msg_or_nil)
     end
 end
 
+local function table_covers(actual, expected)
+    if type(actual) ~= 'table' and type(expected) ~= 'table' then
+        error('Argument 1 and 2 must be tables')
+    end
+    local sliced = {}
+    for k, _ in pairs(expected) do
+        sliced[k] = actual[k]
+    end
+    return _is_table_equals(sliced, expected)
+end
+
+function M.assert_covers(actual, expected, message)
+    if not table_covers(actual, expected) then
+        local str_actual, str_expected = prettystr_pairs(actual, expected)
+        failure(string.format('expected %s to cover %s', str_actual, str_expected), message, 2)
+    end
+end
+
+function M.assert_not_covers(actual, expected, message)
+    if table_covers(actual, expected) then
+        local str_actual, str_expected = prettystr_pairs(actual, expected)
+        failure(string.format('expected %s to not cover %s', str_actual, str_expected), message, 2)
+    end
+end
+
 ------------------------------------------------------------------
 --                  String assertion
 ------------------------------------------------------------------

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -44,11 +44,13 @@ g.test_assert_covers = function()
     subject({a = 1, b = 2, c = 3}, {a = 1})
     subject({a = 1, b = 2, c = 3}, {a = 1, c = 3})
     subject({a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3})
+    subject({a = box.NULL}, {a = box.NULL})
 
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 2})
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 1, b = 1})
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3, d = 4})
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {d = 1})
+    t.assert_error(subject, {a = nil}, {a = box.NULL})
 end
 
 g.test_assert_not_covers = function()
@@ -57,11 +59,13 @@ g.test_assert_not_covers = function()
     subject({a = 1, b = 2, c = 3}, {a = 1, b = 1})
     subject({a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3, d = 4})
     subject({a = 1, b = 2, c = 3}, {d = 1})
+    subject({a = nil}, {a = box.NULL})
 
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {})
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 1})
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 1, c = 3})
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3})
+    t.assert_error(subject, {a = box.NULL}, {a = box.NULL})
 end
 
 g.test_assert_type = function()


### PR DESCRIPTION
Is it enough for #56 ? It does not print missing/different elements.