### PR TITLE
Improvements for `group` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix not working `--exclude`, `--pattern` options
 - Fix error messages for `*_covers` matchers
 - Raise error when `group()` is called with existing group name.
+- Allow dot in group name.
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Raise error when `group()` is called with existing group name.
 - Allow dot in group name.
 - Prevent using `/` in group name.
+- Decide group name from filename for `group()` call without args.
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix not working `--exclude`, `--pattern` options
 - Fix error messages for `*_covers` matchers
+- Raise error when `group()` is called with existing group name.
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix error messages for `*_covers` matchers
 - Raise error when `group()` is called with existing group name.
 - Allow dot in group name.
+- Prevent using `/` in group name.
 
 # 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Define tests.
 -- test/feature_test.lua
 local t = require('luatest')
 local g = t.group('feature')
+-- Default name is inferred from caller filename when possible.
+-- For `test/a/b/c_d_test.lua` it will be `a.b.c_d`.
+-- So `local g = t.group()` works the same way.
 
 -- Tests. All properties with name staring with `test` are treated as test cases.
 g.test_example_1 = function() ... end

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -235,7 +235,8 @@ return luatest
 --- Create group of tests.
 --
 -- @function group
--- @string name
+-- @string[opt] name Default name is inferred from caller filename when possible.
+--  For `test/a/b/c_d_test.lua` it will be `a.b.c_d`.
 -- @return @{TestGroup}
 
 --- Skip a running test.

--- a/luatest/luaunit.lua
+++ b/luatest/luaunit.lua
@@ -34,6 +34,9 @@ M.group = function(name)
         error('Test group already exists: ' .. name ..
             '. To modify existing group use `luatest.tests[name]`.')
     end
+    if name:find('/') then
+        error('Group name must not contain `/`: ' .. name)
+    end
     M.tests[name] = {}
     return M.tests[name]
 end

--- a/luatest/luaunit.lua
+++ b/luatest/luaunit.lua
@@ -28,11 +28,13 @@ M.LIST_DIFF_ANALYSIS_THRESHOLD  = 10    -- display deep analysis for more than 1
 M.GLOBAL_TESTS = true -- Use either _G or M.tests as tests container
 M.tests = {}
 
-M.group = function( name )
-    -- Define named test group.
-    if not M.tests[name] then
-        M.tests[name] = {}
+--- Define named test group.
+M.group = function(name)
+    if M.tests[name] then
+        error('Test group already exists: ' .. name ..
+            '. To modify existing group use `luatest.tests[name]`.')
     end
+    M.tests[name] = {}
     return M.tests[name]
 end
 

--- a/luatest/luaunit.lua
+++ b/luatest/luaunit.lua
@@ -30,6 +30,13 @@ M.tests = {}
 
 --- Define named test group.
 M.group = function(name)
+    if not name then
+        local test_filename = assert(
+            debug.getinfo(2, "S").source:match('.*/test/(.+)_test%.lua'),
+            'Can not guess test name from the source file name'
+        )
+        name = test_filename:gsub('/', '.')
+    end
     if M.tests[name] then
         error('Test group already exists: ' .. name ..
             '. To modify existing group use `luatest.tests[name]`.')

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -96,3 +96,10 @@ g.test_group_with_dot = function()
     t.assert_equals(result, 0)
     t.assert(run)
 end
+
+g.test_group_with_slash_in_name_fails = function()
+    local result = helper.run_suite(function(lu2)
+        t.assert_error_msg_contains('Group name must not contain `/`: asd/qwe', lu2.group, 'asd/qwe')
+    end)
+    t.assert_equals(result, 0)
+end

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -87,3 +87,12 @@ g.test_group_with_existing_name_fails = function()
     end)
     t.assert_equals(result, 0)
 end
+
+g.test_group_with_dot = function()
+    local run
+    local result = helper.run_suite(function(lu2)
+        lu2.group('asd.qwe').test_1 = function() run = true end
+    end)
+    t.assert_equals(result, 0)
+    t.assert(run)
+end

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -103,3 +103,11 @@ g.test_group_with_slash_in_name_fails = function()
     end)
     t.assert_equals(result, 0)
 end
+
+g.test_group_sets_default_group_name_from_filename = function()
+    local result = helper.run_suite(function(lu2)
+        local g2 = lu2.group()
+        t.assert_is(lu2.tests.luatest, g2)
+    end)
+    t.assert_equals(result, 0)
+end

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -1,5 +1,7 @@
 local t = require('luatest')
-local g = t.group('luaunit')
+local g = t.group('luatest')
+
+local helper = require('test.helper')
 
 g.test_assert_tnt_specific = function()
     t.assert(true)
@@ -75,4 +77,13 @@ g.test_assert_type = function()
 
     t.assert_error(subject, 1, 'string')
     t.assert_error(subject, '1', 'number')
+end
+
+g.test_group_with_existing_name_fails = function()
+    local result = helper.run_suite(function(lu2)
+        lu2.group('asd')
+        t.assert_error_msg_contains('Test group already exists: asd', lu2.group, 'asd')
+        lu2.group('qwe')
+    end)
+    t.assert_equals(result, 0)
 end

--- a/test/sub_dir/group_test.lua
+++ b/test/sub_dir/group_test.lua
@@ -1,0 +1,6 @@
+local t = require('luatest')
+local g = t.group()
+
+g.test_default_group_name = function()
+    t.assert_is(t.tests['sub_dir.group'], g)
+end


### PR DESCRIPTION
- Raise error when `group()` is called with existing group name.
- Allow dot in group name.
- Prevent using `/` in group name.
- Decide group name from filename for `group()` call without args.