### PR TITLE
Fix performance issue with large errors messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `assert` returns input values.
 - `assert[_not]_equals` works for Tarantool's box.tuple.
 - Print tables in lua-compatible way in errors.
+- Fix performance issue with large errors messages.
 
 # 0.3.0
 

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -42,14 +42,14 @@ end
 
 g.test_skip_if_tnt_specific = function()
     assert_any_error(t.skip_if, box.NULL, 'unexpected')
-    t.assert_error_msg_contains(t.SKIP_PREFIX, function() t.skip_if(true, 'expected') end)
-    t.assert_error_msg_contains(t.SKIP_PREFIX, function() t.skip_if({}, 'expected') end)
+    t.assert_equals(t.assert_error(t.skip_if, true, 'expected').status, t.NodeStatus.SKIP)
+    t.assert_equals(t.assert_error(t.skip_if, {}, 'expected').status, t.NodeStatus.SKIP)
 end
 
 g.test_success_if_tnt_specific = function()
     assert_any_error(t.success_if, box.NULL)
-    t.assert_error_msg_contains(t.SUCCESS_PREFIX, function() t.success_if(true) end)
-    t.assert_error_msg_contains(t.SUCCESS_PREFIX, function() t.success_if({}) end)
+    t.assert_equals(t.assert_error(t.success_if, true).status, t.NodeStatus.SUCCESS)
+    t.assert_equals(t.assert_error(t.success_if, {}).status, t.NodeStatus.SUCCESS)
 end
 
 g.test_assert_aliases = function ()

--- a/test/luaunit_test.lua
+++ b/test/luaunit_test.lua
@@ -1,6 +1,9 @@
 local t = require('luatest')
 local g = t.group()
 
+local helper = require('test.helper')
+local clock = require('clock')
+
 g.test_pretystr = function()
     local subject = t.prettystr
     t.assert_equals(subject({['a-b'] = 1, ab = 2, [10] = 10}), '{[10] = 10, ["a-b"] = 1, ab = 2}')
@@ -13,4 +16,16 @@ g.test_pretystr = function()
     end
     table.insert(expected_large_format, '}')
     t.assert_equals(subject(large_table), table.concat(expected_large_format, '\n'))
+end
+
+g.test_pretystr_huge_table = function()
+    local str_table = {}
+    for _ = 1, 15000 do table.insert(str_table, 'a') end
+    local str = table.concat(str_table, '\n')
+    local start = clock.time()
+    local result = helper.run_suite(function(lu2)
+        lu2.group().test = function() t.skip(str) end
+    end)
+    t.assert_equals(result, 0)
+    t.assert_almost_equals(clock.time() - start, 0, 0.5)
 end


### PR DESCRIPTION
Luaunit added custom prefixes to error messages
to control flow (skip, success, failures in assertions).
It required to match this strings over all prefixes to find
out the valid status, which resulted in great performance
degradation when error message is quite large.

Now it throws tables with custom format, which has
desired node status in separate field.