### PR TITLE
Fix handling any non-string errors

### DIFF
--- a/luatest/luaunit.lua
+++ b/luatest/luaunit.lua
@@ -2304,6 +2304,10 @@ local LuaUnit_MT = { __index = M.LuaUnit }
             end
         end)
 
+        if type(err.msg) ~= 'string' then
+            err.msg = prettystr(err.msg)
+        end
+
         if self.currentCount > 1 then
             err.msg = tostring(err.msg) .. '\nIteration ' .. self.currentCount
         end

--- a/test/luaunit_test.lua
+++ b/test/luaunit_test.lua
@@ -29,3 +29,14 @@ g.test_pretystr_huge_table = function()
     t.assert_equals(result, 0)
     t.assert_almost_equals(clock.time() - start, 0, 0.5)
 end
+
+g.test_custom_errors = function()
+    local function assert_no_exception(fn)
+        local result = helper.run_suite(function(lu2)
+            lu2.group().test = fn
+        end)
+        t.assert_equals(result, 1)
+    end
+    assert_no_exception(function() error(123ULL) end)
+    assert_no_exception(function() error({a = 1}) end)
+end


### PR DESCRIPTION
Before this patch raised non-string errors failed with:
- attempt to concatenate 'uint64_t' and 'string'
- attempt to concatenate 'struct error' and 'string'
- attempt to concatenate field 'msg' (a table value)