### PR TITLE
Preserve stacktrace in helpers.retrying

### DIFF
--- a/luatest/helpers.lua
+++ b/luatest/helpers.lua
@@ -66,11 +66,11 @@ function helpers.retrying(config, fn, ...)
         if ok then
             return result
         end
+        if (clock.time() - started_at) > timeout then
+            return fn(...)
+        end
         log.debug('Retrying in ' .. delay .. ' sec. due to error:')
         log.debug(result)
-        if (clock.time() - started_at) > timeout then
-            error(result)
-        end
         fiber.sleep(delay)
     end
 end

--- a/test/helpers_test.lua
+++ b/test/helpers_test.lua
@@ -28,12 +28,12 @@ end
 
 g.test_rescuing_failure = function()
     local retry = 0
-    t.assert_error_msg_contains('test-error', function()
+    t.assert_error_msg_equals('test-error', function()
         helpers.retrying({delay = 0.1, timeout = 0.5}, function(a, b)
             t.assert_equals(a, 1)
             t.assert_equals(b, 2)
             retry = retry + 1
-            error('test-error')
+            error('test-error', 0)
         end, 1, 2)
     end)
     t.assert_almost_equals(retry, 6, 1)


### PR DESCRIPTION
Traceback provided by retrying error usually looks as follows:

```txt
363 =========================================================
364 Tests with errors:
365 ------------------
366 1) bootstrap.test_cookie_change
367 /.rocks/share/tarantool/luatest/helpers.lua:72: /.rocks/share/tarantool/luatest/server.lua:113: Network is unreachable
368 stack traceback:
369 	/.rocks/share/tarantool/luatest/helpers.lua:72: in function 'retrying'
370 	.../tarantool/cartridge/test/integration/bootstrap_test.lua:68: in function 'bootstrap.test_cookie_change'
```

Pointing on the helpers.lua is misleading, so this patch fixes it by eliminating unnecessary stack frames if the error occurs.