### PR TITLE
Fix type check in `assert_covers` matcher

### DIFF
--- a/luatest/luaunit.lua
+++ b/luatest/luaunit.lua
@@ -1146,7 +1146,7 @@ function M.assert_items_equals(actual, expected, extra_msg_or_nil)
 end
 
 local function table_covers(actual, expected)
-    if type(actual) ~= 'table' and type(expected) ~= 'table' then
+    if type(actual) ~= 'table' or type(expected) ~= 'table' then
         error('Argument 1 and 2 must be tables')
     end
     local sliced = {}

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -73,6 +73,8 @@ g.test_assert_covers = function()
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3, d = 4})
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {d = 1})
     t.assert_error(subject, {a = nil}, {a = box.NULL})
+    t.assert_error_msg_contains('Argument 1 and 2 must be tables',
+        subject, {a = 1, b = 2, c = 3}, nil)
 end
 
 g.test_assert_not_covers = function()
@@ -88,6 +90,8 @@ g.test_assert_not_covers = function()
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 1, c = 3})
     t.assert_error(subject, {a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3})
     t.assert_error(subject, {a = box.NULL}, {a = box.NULL})
+    t.assert_error_msg_contains('Argument 1 and 2 must be tables',
+        subject, {a = 1, b = 2, c = 3}, nil)
 end
 
 g.test_assert_type = function()


### PR DESCRIPTION
Make `assert_covers` matcher to fail with appropriate message
instead of:

```
bad argument #1 to 'pairs' (table expected, got nil)
```