### PR TITLE
Fix tarantool headers lookup

### DIFF
--- a/luatest-scm-1.rockspec
+++ b/luatest-scm-1.rockspec
@@ -13,6 +13,11 @@ dependencies = {
     'lua >= 5.1',
     'checks >= 3.0.0',
 }
+external_dependencies = {
+    TARANTOOL = {
+        header = 'tarantool/module.h',
+    },
+}
 build = {
     type = 'cmake',
     variables = {


### PR DESCRIPTION
When tarantool is installed outside /usr/local, cmake encounters
problems finding it. To determine the path it uses TARANTOOL_DIR hint,
which is passed from the rockspec external_dependencies.

See also: https://github.com/tarantool/modulekit/issues/2