### PR TITLE
Fix server connect_net_box reconnecting

### DIFF
--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -112,7 +112,7 @@ end
 --- Establish `net.box` connection.
 -- It's available in `net_box` field.
 function Server:connect_net_box()
-    if self.net_box then
+    if self.net_box and self.net_box:is_connected() then
         return self.net_box
     end
     if not self.net_box_uri then

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -86,6 +86,11 @@ end
 g.test_net_box = function()
     server:connect_net_box()
     t.assert_equals(server.net_box:eval('return os.getenv("custom_env")'), 'test_value')
+
+    server.net_box:close()
+    t.assert_equals(server.net_box.state, 'closed')
+    server:connect_net_box()
+    t.assert_equals(server.net_box.state, 'active')
 end
 
 g.test_inherit = function()


### PR DESCRIPTION
Net.box connections shouldn't be cached if it's not active