### PR TITLE
Add assert_includes_items matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `assert_is` treats `box.NULL` and `nil` as different values.
 - Add luacov integration.
+- Fix `assert_items_equals` for repeated values. Add support for `tuple` items.
 
 # 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `assert_is` treats `box.NULL` and `nil` as different values.
 - Add luacov integration.
 - Fix `assert_items_equals` for repeated values. Add support for `tuple` items.
+- Add `assert_includes_items` matcher.
 
 # 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ t.defaults({shuffle = 'group'})
 | `assert_error_msg_matches (pattern, fn, ...)` | |
 | `assert_eval_to_false (value[, message])` | Alias for assert_not. |
 | `assert_eval_to_true (value[, message])` | Alias for assert. |
+| `assert_includes_items (actual, expected[, message])` | Checks that actual includes all items of expected. |
 | `assert_is (actual, expected[, message])` | Check that values are the same. |
 | `assert_is_not (actual, expected[, message])` | Check that values are not the same. |
 | `assert_items_equals (actual, expected[, message])` | Checks equality of tables regardless of the order of elements. |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ t.defaults({shuffle = 'group'})
 | :--- | --- |
 | `assert (value[, message])` | Check that value is truthy. |
 | `assert_almost_equals (actual, expected, margin[, message])` | Check that two floats are close by margin. |
-| `assert_covers (actual, expected[, message])` | Checks that map contains the other one. |
+| `assert_covers (actual, expected[, message])` | Checks that actual map includes expected one. |
 | `assert_equals (actual, expected[, message[, deep_analysis]])` | Check that two values are equal. |
 | `assert_error (fn, ...)` | Check that calling fn raises an error. |
 | `assert_error_msg_contains (expected_partial, fn, ...)` | |

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ t.defaults({shuffle = 'group'})
 | `assert_eval_to_true (value[, message])` | Alias for assert. |
 | `assert_is (actual, expected[, message])` | Check that values are the same. |
 | `assert_is_not (actual, expected[, message])` | Check that values are not the same. |
-| `assert_items_equals (actual, expected[, message])` | Check that the items of table expected are contained in table actual. |
+| `assert_items_equals (actual, expected[, message])` | Checks equality of tables regardless of the order of elements. |
 | `assert_nan (value[, message])` | |
 | `assert_not (value[, message])` | Check that value is falsy. |
 | `assert_not_almost_equals (actual, expected, margin[, message])` | Check that two floats are not close by margin. |

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -136,8 +136,7 @@ return luatest
 -- @param expected
 -- @string[opt] message
 
---- Check that the items of table expected are contained in table actual.
--- Warning, this function is at least O(n^2)
+--- Checks equality of tables regardless of the order of elements.
 --
 -- @function assert_items_equals
 -- @param actual

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -122,6 +122,13 @@ return luatest
 -- @param value
 -- @string[opt] message
 
+--- Checks that actual includes all items of expected.
+--
+-- @function assert_includes_items
+-- @param actual
+-- @param expected
+-- @string[opt] message
+
 --- Check that values are the same.
 --
 -- @function assert_is

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -60,7 +60,7 @@ return luatest
 -- @number margin
 -- @string[opt] message
 
---- Checks that map contains the other one.
+--- Checks that actual map includes expected one.
 --
 -- @function assert_covers
 -- @tab actual

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -16,6 +16,10 @@ function helper.assert_failure(...)
     return err
 end
 
+function helper.assert_failure_equals(msg, ...)
+    t.assert_equals(helper.assert_failure(...).message, msg)
+end
+
 function helper.assert_failure_matches(msg, ...)
     t.assert_str_matches(helper.assert_failure(...).message, msg)
 end

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -46,6 +46,12 @@ g.test_assert_equals_tnt_tuples = function()
     t.assert_equals(1ULL, 0ULL + 1)
 end
 
+g.test_assert_items_equals_tnt_tuples = function()
+    t.assert_items_equals({box.tuple.new(1)}, {box.tuple.new(1)})
+    helper.assert_failure_contains('Content of the tables are not identical',
+        t.assert_items_equals, {box.tuple.new(1)}, {box.tuple.new(2)})
+end
+
 g.test_fail_if_tnt_specific = function()
     t.fail_if(box.NULL, 'unexpected')
     t.assert_error(function() t.fail_if(true, 'expected') end)

--- a/test/luaunit/assertions_error_test.lua
+++ b/test/luaunit/assertions_error_test.lua
@@ -1,16 +1,9 @@
 local t = require('luatest')
 local g = t.group()
 
-local function assert_failure(...)
-    local err = t.assert_error(...)
-    t.assert_equals(err.class, 'LuaUnitError')
-    return err
-end
-
-local function assert_failure_equals(msg, ...)
-    local err = t.assert_error(...)
-    t.assert_equals(err.message, msg)
-end
+local helper = require('test.helper')
+local assert_failure = helper.assert_failure
+local assert_failure_equals = helper.assert_failure_equals
 
 local function f()
 end

--- a/test/luaunit/assertions_test.lua
+++ b/test/luaunit/assertions_test.lua
@@ -1,11 +1,8 @@
 local t = require('luatest')
 local g = t.group()
 
-local function assert_failure(...)
-    local err = t.assert_error(...)
-    t.assert_covers(err, {class = 'LuaUnitError'})
-    return err
-end
+local helper = require('test.helper')
+local assert_failure = helper.assert_failure
 
 local function assertBadFindArgTable(...)
     t.assert_error_msg_matches(".* bad argument .* to 'find' %(string expected, got table%)", ...)

--- a/test/luaunit/assertions_test.lua
+++ b/test/luaunit/assertions_test.lua
@@ -336,6 +336,25 @@ function g.test_assert_items_equals()
     assert_failure(t.assert_items_equals, {one=1,two=2,three=3}, {two=2,one=1})
 end
 
+function g.test_assert_includes_items()
+    t.assert_includes_items({},{})
+    t.assert_includes_items({1,2,3}, {3,1,2})
+    t.assert_includes_items({nil},{nil})
+    t.assert_includes_items({one=1,two=2,three=3}, {two=2,one=1,three=3})
+    t.assert_includes_items({one=1,two=2,three=3}, {a=1,b=2,c=3})
+    t.assert_includes_items({1,2,three=3}, {3,1,two=2})
+
+    t.assert_includes_items({1},{})
+    t.assert_includes_items({1,2,3,4}, {3,1,2})
+    t.assert_includes_items({1,1,2,3}, {3,1,2})
+
+    assert_failure(t.assert_includes_items, {}, {1})
+    assert_failure(t.assert_includes_items, nil, {1})
+    assert_failure(t.assert_includes_items, {}, nil)
+    assert_failure(t.assert_includes_items, {1,2,3}, {1,2,3,4})
+    assert_failure(t.assert_includes_items, {1,2,3}, {1,1,2,3})
+end
+
 function g.test_assert_nan()
     assert_failure(t.assert_nan, "hi there!")
     assert_failure(t.assert_nan, nil)

--- a/test/luaunit/assertions_test.lua
+++ b/test/luaunit/assertions_test.lua
@@ -298,7 +298,6 @@ function g.test_assert_str_matches()
 end
 
 function g.test_assert_items_equals()
-    t.assert_items_equals(nil, nil)
     t.assert_items_equals({},{})
     t.assert_items_equals({1,2,3}, {3,1,2})
     t.assert_items_equals({nil},{nil})
@@ -315,6 +314,10 @@ function g.test_assert_items_equals()
     assert_failure(t.assert_items_equals, {one=1,two=2,three=3}, {a=1,b=2,c=3,d=4})
     assert_failure(t.assert_items_equals, {1,2,three=3}, {3,4,a=1,b=2})
     assert_failure(t.assert_items_equals, {1,2,three=3,four=4}, {3,a=1,b=2})
+
+    assert_failure(t.assert_items_equals, {1,1,2,3}, {1,2,3})
+    assert_failure(t.assert_items_equals, {1,2,3}, {1,1,2,3})
+    assert_failure(t.assert_items_equals, {1,1,2,3}, {1,2,3,3})
 
     t.assert_items_equals({one=1,two={1,2},three=3}, {one={1,2},two=1,three=3})
     t.assert_items_equals({one=1,

--- a/test/luaunit/error_msg_test.lua
+++ b/test/luaunit/error_msg_test.lua
@@ -1,23 +1,10 @@
 local t = require('luatest')
 local g = t.group()
 
-local function assert_failure(...)
-    local err = t.assert_error(...)
-    t.assert_covers(err, {class = 'LuaUnitError'})
-    return err
-end
-
-local function assert_failure_equals(msg, ...)
-    t.assert_equals(assert_failure(...).message, msg)
-end
-
-local function assert_failure_matches(msg, ...)
-    t.assert_str_matches(assert_failure(...).message, msg)
-end
-
-local function assert_failure_contains(msg, ...)
-    t.assert_str_contains(assert_failure(...).message, msg)
-end
+local helper = require('test.helper')
+local assert_failure_matches = helper.assert_failure_matches
+local assert_failure_contains = helper.assert_failure_contains
+local assert_failure_equals = helper.assert_failure_equals
 
 function g.test_assert_equalsMsg()
     assert_failure_equals('expected: 2, actual: 1', t.assert_equals, 1, 2 )

--- a/test/luaunit/utility_test.lua
+++ b/test/luaunit/utility_test.lua
@@ -3,15 +3,8 @@ local g = t.group()
 
 local fun = require('fun')
 
-local function assert_failure(...)
-    local err = t.assert_error(...)
-    t.assert_equals(err.class, 'LuaUnitError')
-    return err
-end
-
-local function assert_failure_matches(msg, ...)
-    t.assert_str_matches(assert_failure(...).message, msg)
-end
+local helper = require('test.helper')
+local assert_failure_matches = helper.assert_failure_matches
 
 local function range(start, stop)
     -- return list of {start ... stop}


### PR DESCRIPTION
\+ Fix `assert_items_equals` for repeated values. Add support for `tuple` items.

Fixes #80 