### PR TITLE
`assert_equals` uses same comparison rules for nested values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add luacov integration.
 - Fix `assert_items_equals` for repeated values. Add support for `tuple` items.
 - Add `assert_includes_items` matcher.
+- `assert_equals` uses same comparison rules for nested values.
 
 # 0.4.0
 

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -97,12 +97,14 @@ g.test_assert_covers = function()
     subject({a = 1, b = 2, c = 3}, {a = 1, c = 3})
     subject({a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3})
     subject({a = box.NULL}, {a = box.NULL})
+    subject({a = box.tuple.new(1)}, {a = box.tuple.new(1)})
 
     helper.assert_failure(subject, {a = 1, b = 2, c = 3}, {a = 2})
     helper.assert_failure(subject, {a = 1, b = 2, c = 3}, {a = 1, b = 1})
     helper.assert_failure(subject, {a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3, d = 4})
     helper.assert_failure(subject, {a = 1, b = 2, c = 3}, {d = 1})
     helper.assert_failure(subject, {a = nil}, {a = box.NULL})
+    helper.assert_failure(subject, {a = box.tuple.new(1)}, {a = box.tuple.new(2)})
     helper.assert_failure_contains('Argument 1 and 2 must be tables', subject, {a = 1, b = 2, c = 3}, nil)
 end
 
@@ -120,6 +122,13 @@ g.test_assert_not_covers = function()
     helper.assert_failure(subject, {a = 1, b = 2, c = 3}, {a = 1, b = 2, c = 3})
     helper.assert_failure(subject, {a = box.NULL}, {a = box.NULL})
     helper.assert_failure_contains('Argument 1 and 2 must be tables', subject, {a = 1, b = 2, c = 3}, nil)
+end
+
+g.test_assert_includes_items = function()
+    local subject = t.assert_includes_items
+    subject({1, box.tuple.new(1)}, {box.tuple.new(1)})
+
+    helper.assert_failure(subject, {box.tuple.new(1)}, {box.tuple.new(2)})
 end
 
 g.test_assert_type = function()

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -21,8 +21,14 @@ end
 
 g.test_assert_equals_box_null = function()
     t.assert_equals(box.NULL, nil)
-    helper.assert_failure_contains('Received the not expected value', t.assert_not_equals, box.NULL, nil)
+    t.assert_equals({box.NULL}, {nil})
+    t.assert_equals({1, box.NULL, 3}, {1, nil, 3})
+    helper.assert_failure(t.assert_equals, box.NULL, 1)
+    helper.assert_failure(t.assert_equals, {1, box.NULL, 3}, {1, 3})
+    helper.assert_failure(t.assert_equals, {1, nil, 3}, {1, 3})
+
     t.assert_not_equals(box.NULL, 1ULL)
+    helper.assert_failure_contains('Received the not expected value', t.assert_not_equals, box.NULL, nil)
 end
 
 g.test_assert_is_box_null = function()
@@ -37,10 +43,14 @@ g.test_assert_equals_tnt_tuples = function()
     t.assert_equals(box.tuple.new(1), box.tuple.new(1))
     t.assert_equals(box.tuple.new(1, 'a', box.NULL), box.tuple.new(1, 'a', box.NULL))
     t.assert_equals(box.tuple.new(1, {'a'}), box.tuple.new(1, {'a'}))
+    t.assert_equals({box.tuple.new(1)}, {box.tuple.new(1)})
+    t.assert_equals({box.tuple.new(1)}, {{1}})
+    helper.assert_failure(t.assert_equals, box.tuple.new(1), box.tuple.new(2))
 
     t.assert_not_equals(box.tuple.new(1), box.tuple.new(2))
-    t.assert_not_equals(box.tuple.new(1, 'a', box.NULL), box.tuple.new(1, 'a'))
+    t.assert_not_equals(box.tuple.new(1, 'a', box.NULL, {}), box.tuple.new(1, 'a'))
     t.assert_not_equals(box.tuple.new(1, {'a'}), box.tuple.new(1, {'b'}))
+    helper.assert_failure(t.assert_not_equals, box.tuple.new(1), box.tuple.new(1))
 
     -- Check that other cdata values works fine.
     t.assert_equals(1ULL, 0ULL + 1)

--- a/test/luaunit/utility_test.lua
+++ b/test/luaunit/utility_test.lua
@@ -155,7 +155,7 @@ function g.test_prefix_string()
     t.assert_equals(t.private.prefix_string('12 ', 'ab\ncd\nde'), '12 ab\n12 cd\n12 de')
 end
 
-function g.test_is_table_equals()
+function g.test_equals_for_tables()
     -- Make sure that _is_table_equals() doesn't fall for these traps
     -- (See https://github.com/bluebird75/luaunit/issues/48)
     local A, B, C = {}, {}, {}


### PR DESCRIPTION
This makes it consistent for comparisons on any depth.

Before the patch these passed

    t.assert_equals(tuple(1), tuple(1))
    t.assert_equals(box.NULL, nil)

but these failed

    t.assert_equals({tuple(1)}, {tuple(1)})
    t.assert_equals({1, box.NULL, 2}, {1, nil, 2})

After the patch all assertions above pass.

Also fixed incorrect behaviour of `assert_not_equals`.

Fixes #90 