### PR TITLE
fix io to fio hack

### DIFF
--- a/.github/workflows/push_rockspec.yaml
+++ b/.github/workflows/push_rockspec.yaml
@@ -1,0 +1,45 @@
+name: Push rockspec
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+env:
+  ROCK_NAME: "luatest"
+
+jobs:
+  push-scm-rockspec:
+    runs-on: [ ubuntu-latest ]
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@master
+
+      - uses: tarantool/rocks.tarantool.org/github-action@master
+        with:
+          auth: ${{ secrets.ROCKS_AUTH }}
+          files: ${{ env.ROCK_NAME }}-scm-1.rockspec
+
+  push-tagged-rockspec:
+    runs-on: [ ubuntu-latest ]
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@master
+
+      # https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions
+      - name: Set env
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Create release rockspec
+        run: |
+          sed \
+            -e "s/branch = '.\+'/tag = '${GIT_TAG}'/g" \
+            -e "s/version = '.\+'/version = '${GIT_TAG}-1'/g" \
+            ${{ env.ROCK_NAME }}-scm-1.rockspec > ${{ env.ROCK_NAME }}-${GIT_TAG}-1.rockspec
+
+      - uses: tarantool/rocks.tarantool.org/github-action@master
+        with:
+          auth: ${{ secrets.ROCKS_AUTH }}
+          files: ${{ env.ROCK_NAME }}-${GIT_TAG}-1.rockspec

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -1,0 +1,36 @@
+name: Run tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run-tests-ce:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
+    strategy:
+      matrix:
+        tarantool-version: ["1.10", "2.6", "2.7", "2.8"]
+      fail-fast: false
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install requirements for community
+        run: |
+          curl -L https://tarantool.io/installer.sh | sudo VER=${{ matrix.tarantool-version }} bash
+          sudo apt install -y tarantool-dev
+          tarantool --version
+          cmake .
+          make bootstrap
+
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
+      - name: Run linter
+        run: make lint
+
+      - name: Run tests
+        run: bin/luatest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /lua_modules
 .luarocks
 .rocks
+.idea
 /doc
 
 /tmp/*

--- a/test/capture_test.lua
+++ b/test/capture_test.lua
@@ -1,3 +1,4 @@
+local fio = require('fio')
 local t = require('luatest')
 local g = t.group()
 
@@ -10,6 +11,31 @@ g.teardown = function()
     capture:disable()
 end
 
+g.before_all(function()
+    local err
+    g.fd, err = fio.open('/dev/null')
+    assert(err == nil, tostring(err))
+
+    -- It is not really needed
+    g.fd:close()
+end)
+
+-- Hack until https://github.com/tarantool/tarantool/issues/1338
+-- is not implemented.
+local function stdout_write(s)
+    g.fd.fh = 1
+    local res, err = g.fd:write(s)
+    g.fd.fh = -1
+    return res, err
+end
+
+local function stderr_write(s)
+    g.fd.fh = 2
+    local res, err = g.fd:write(s)
+    g.fd.fh = -1
+    return res, err
+end
+
 g.test_flush = function()
     t.assert_equals(capture:flush(), {stdout = '', stderr = ''})
     io.stdout:write('test-out')
@@ -18,24 +44,12 @@ g.test_flush = function()
     t.assert_equals(capture:flush(), {stdout = '', stderr = ''})
 end
 
--- io.write is blocking, fio is not.
-local function io_to_fio(io)
-    local fd = require('ffi').C.fileno(io)
-    local dev_null, err = require('fio').open('/dev/null')
-    assert(dev_null, tostring(err))
-    local fio_file_mt = getmetatable(dev_null)
-    dev_null:close()
-    local file = {fh = fd}
-    setmetatable(file, fio_file_mt)
-    return file
- end
-
 g.test_flush_large_strings = function()
     local buffer_size = 65536
     local out = ('out'):rep(buffer_size / 3)
     local err = ('error'):rep(buffer_size / 5 + 1)
-    io_to_fio(io.stdout):write(out)
-    io_to_fio(io.stderr):write(err)
+    stdout_write(out)
+    stderr_write(err)
     -- manually compare strings to avoid large diffs
     local captured = capture:flush()
     t.assert_equals(#captured.stdout, #out)


### PR DESCRIPTION
This patch removes io_to_fio hack in favour a new one. Previous
version used fio metatable and it was broken after
tarantool/tarantool@3d5b4da. This patch just set file descriptor
numer to stdout (2) or stderr (3) when it required. So it seems
enough to solve this problem.

An alternative way is to use `struct fio_handle` directly. But it
seems more danger way than proposed.

Closes #112