### PR TITLE
Write execution time for every test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `_le`, `_lt`, `_ge`, `_gt` assertions.
+- Write execution time for each test in the verbose mode.
+
 ## 0.5.2
 
 - Throw parser error when .json is accessed on response with invalid body.

--- a/luatest/output/text.lua
+++ b/luatest/output/text.lua
@@ -23,6 +23,8 @@ end
 function Output.mt:end_test(node)
     if node:is('success') then
         if self.verbosity >= self.class.VERBOSITY.VERBOSE then
+            local duration = string.format("(%0.3fs) ", node.duration)
+            io.stdout:write(duration)
             io.stdout:write("Ok\n")
         else
             io.stdout:write(".")
@@ -30,7 +32,8 @@ function Output.mt:end_test(node)
         end
     else
         if self.verbosity >= self.class.VERBOSITY.VERBOSE then
-            print(node.status)
+            local duration = string.format("(%0.3fs) ", node.duration)
+            print(duration .. node.status)
             print(node.message)
         else
             -- write only the first character of status E, F or S


### PR DESCRIPTION
Now execution time is written for each test and verbose mode looks like this: 

```
    assertions.test_assert_equals_for_cdata ... (0.010s) fail
/home/aleksandr/tarantool/luatest/test/assertions_test.lua:28: Received unexpected value: 1
    server.test_http_request_post_json_with_custom_headers ... (0.012s) Ok
    server.test_net_box ... (0.023s) Ok
    server.test_inherit ... (0.005s) Ok
=========================================================
Ran 207 tests in 8.097 seconds, 207 successes, 0 failures

```

I didn't forget about

- [ ] Tests
- [x] Changelog
- [ ] Documentation

Close #128 