### PR TITLE
Repeat tests' names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add `_le`, `_lt`, `_ge`, `_gt` assertions.
 - Write execution time for each test in the verbose mode.
+- When capture is disabled and verbose mode is on test names are printed
+  twice: at the start and at the end with result.
 
 ## 0.5.2
 

--- a/luatest/output/generic.lua
+++ b/luatest/output/generic.lua
@@ -5,6 +5,7 @@ local Output = require('luatest.class').new({
         QUIET   = 0,
         LOW     = 1,
         VERBOSE = 20,
+        REPEAT  = 21,
     },
 })
 

--- a/luatest/output/text.lua
+++ b/luatest/output/text.lua
@@ -17,12 +17,18 @@ end
 function Output.mt:start_test(test) -- luacheck: no unused
     if self.verbosity >= self.class.VERBOSITY.VERBOSE then
         io.stdout:write("    ", test.name, " ... ")
+        if self.verbosity >= self.class.VERBOSITY.REPEAT then
+            io.stdout:write("\n")
+        end
     end
 end
 
 function Output.mt:end_test(node)
     if node:is('success') then
         if self.verbosity >= self.class.VERBOSITY.VERBOSE then
+            if self.verbosity >= self.class.VERBOSITY.REPEAT then
+                io.stdout:write("    ", node.name, " ... ")
+            end
             local duration = string.format("(%0.3fs) ", node.duration)
             io.stdout:write(duration)
             io.stdout:write("Ok\n")
@@ -32,6 +38,9 @@ function Output.mt:end_test(node)
         end
     else
         if self.verbosity >= self.class.VERBOSITY.VERBOSE then
+            if self.verbosity >= self.class.VERBOSITY.REPEAT then
+                io.stdout:write("    ", node.name, " ... ")
+            end
             local duration = string.format("(%0.3fs) ", node.duration)
             print(duration .. node.status)
             print(node.message)

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -163,6 +163,13 @@ function Runner.parse_cmd_line(args)
         end
     end
 
+    -- end_test will repeat test name for prettier output when capture
+    -- is disabled.
+    if result.enable_capture == false
+    and result.verbosity == GenericOutput.VERBOSITY.VERBOSE then
+        result.verbosity = GenericOutput.VERBOSITY.REPEAT
+    end
+
     return result
 end
 


### PR DESCRIPTION
When capture is disabled test name is written twice: at the start and at the end with its result. 

```
    output.test_tap_verbose_output ... 
1..8
# Started on Wed May 19 10:04:41 2021
# Starting group: group-name
...
# Ran 1 tests in 0.017 seconds, 1 success, 0 failures
    output.test_tap_verbose_output ... (0.197s) Ok

```

I didn't forget about

- [ ] Tests
- [x] Changelog
- [ ] Documentation

Close #131 
