### PR TITLE
Error assertions print return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Write execution time for each test in the verbose mode.
 - When capture is disabled and verbose mode is on test names are printed
   twice: at the start and at the end with result.
+- `assert_error_msg_` assertions print return values if no error is generated
 
 ## 0.5.2
 

--- a/luatest/assertions.lua
+++ b/luatest/assertions.lua
@@ -434,7 +434,10 @@ end
 local function _assert_error_msg_equals(stripFileAndLine, expectedMsg, func, ...)
     local no_error, error_msg = pcall(func, ...)
     if no_error then
-        failure('No error generated when calling function but expected error: ' .. prettystr(expectedMsg), nil, 3)
+        local failure_message = string.format(
+            'Function successfully returned: %s\nExpected error: %s',
+            prettystr(error_msg), prettystr(expectedMsg))
+        failure(failure_message, nil, 3)
     end
     if type(expectedMsg) == "string" and type(error_msg) ~= "string" then
         -- table are converted to string automatically
@@ -496,8 +499,10 @@ end
 function M.assert_error_msg_contains(expected_partial, fn, ...)
     local no_error, error_msg = pcall(fn, ...)
     if no_error then
-        failure('No error generated when calling function but expected error containing: ' ..
-            prettystr(expected_partial), nil, 2)
+        local failure_message = string.format(
+            'Function successfully returned: %s\nExpected error containing: %s',
+            prettystr(error_msg), prettystr(expected_partial))
+        failure(failure_message, nil, 2)
     end
     if type(error_msg) ~= "string" then
         error_msg = tostring(error_msg)
@@ -516,7 +521,10 @@ end
 function M.assert_error_msg_matches(pattern, fn, ...)
     local no_error, error_msg = pcall(fn, ...)
     if no_error then
-        failure('No error generated when calling function but expected error matching: "' .. pattern .. '"', nil, 2)
+        local failure_message = string.format(
+            'Function successfully returned: %s\nExpected error matching: %s',
+            prettystr(error_msg), prettystr(pattern))
+        failure(failure_message, nil, 2)
     end
     if type(error_msg) ~= "string" then
         error_msg = tostring(error_msg)

--- a/test/luaunit/error_msg_test.lua
+++ b/test/luaunit/error_msg_test.lua
@@ -276,8 +276,12 @@ function g.test_assert_error()
 end
 
 function g.test_assert_error_msg_equals()
-    assert_failure_equals('No error generated when calling function but expected error: "bla bla bla"' ,
+    assert_failure_equals('Function successfully returned: nil\nExpected error: "bla bla bla"' ,
+        t.assert_error_msg_equals, 'bla bla bla', function() end)
+    assert_failure_equals('Function successfully returned: 4\nExpected error: "bla bla bla"' ,
         t.assert_error_msg_equals, 'bla bla bla', function(v) return v+1 end, 3)
+    assert_failure_equals('Function successfully returned: {4, 5, 6}\nExpected error: "bla bla bla"' ,
+        t.assert_error_msg_equals, 'bla bla bla', function(v) return {v+1, v+2, v+3} end, 3)
     assert_failure_equals('Error message expected: "bla bla bla"\n' ..
                         'Error message received: "toto xxx"\n' ,
         t.assert_error_msg_equals, 'bla bla bla', function() error('toto xxx',2) end, 3)
@@ -290,16 +294,23 @@ Error message received: {details = "ble ble ble"}
 end
 
 function g.test_assert_errorMsgContains()
-    assert_failure_equals('No error generated when calling function but expected error containing: "bla bla bla"' ,
+    assert_failure_equals('Function successfully returned: nil\nExpected error containing: "bla bla bla"' ,
+        t.assert_error_msg_contains, 'bla bla bla', function() end)
+    assert_failure_equals('Function successfully returned: 4\nExpected error containing: "bla bla bla"' ,
         t.assert_error_msg_contains, 'bla bla bla', function(v) return v+1 end, 3)
+    assert_failure_equals('Function successfully returned: {4, 5, 6}\nExpected error containing: "bla bla bla"' ,
+        t.assert_error_msg_contains, 'bla bla bla', function(v) return {v+1, v+2, v+3} end, 3)
     assert_failure_equals('Error message does not contain: "bla bla bla"\nError message received: "toto xxx"\n' ,
         t.assert_error_msg_contains, 'bla bla bla', function() error('toto xxx',2) end, 3)
 end
 
 function g.test_assert_errorMsgMatches()
-    assert_failure_equals('No error generated when calling function but expected error matching: "bla bla bla"' ,
+    assert_failure_equals('Function successfully returned: nil\nExpected error matching: "bla bla bla"' ,
+        t.assert_error_msg_matches, 'bla bla bla', function() end)
+    assert_failure_equals('Function successfully returned: 4\nExpected error matching: "bla bla bla"' ,
         t.assert_error_msg_matches, 'bla bla bla', function(v) return v+1 end, 3)
-
+    assert_failure_equals('Function successfully returned: {4, 5, 6}\nExpected error matching: "bla bla bla"' ,
+        t.assert_error_msg_matches, 'bla bla bla', function(v) return {v+1, v+2, v+3} end, 3)
     assert_failure_equals('Error message does not match pattern: "bla bla bla"\n' ..
                         'Error message received: "toto xxx"\n' ,
         t.assert_error_msg_matches, 'bla bla bla', function() error('toto xxx',2) end, 3)


### PR DESCRIPTION
If no error is generated during function call then `assert_error_msg_` assertions will print return value like this:

```
Function successfully returned: 4
Expected error: "bla bla bla"
``` 

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #127 
