### PR TITLE
Fix handling flaky tests

### DIFF
--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -404,7 +404,7 @@ end
 function Runner.mt:invoke_test_function(test, iteration)
     local err = self:protected_call(test.group, test.method, test.name)
     if iteration > 1 and err.status ~= 'success' then
-        err.message = tostring(err.message) .. '\nIteration ' .. self.test_iteration
+        err.message = tostring(err.message) .. '\nIteration ' .. iteration
     end
     self:update_status(test, err)
 end

--- a/test/fixtures/flaky.lua
+++ b/test/fixtures/flaky.lua
@@ -1,0 +1,9 @@
+local t = require('luatest')
+
+local g_flaky = t.group('flaky')
+
+local counter = 1
+g_flaky.test_flaky = function()
+    t.fail_if(counter > 1, 'Boo!')
+    counter = counter + 1
+end

--- a/test/runner_test.lua
+++ b/test/runner_test.lua
@@ -28,8 +28,12 @@ g.test_run_error = function()
     t.assert_equals(result, 1)
 end
 
-local function run_file(file)
-    return os.execute('bin/luatest test/fixtures/' .. file)
+local function run_file(file, opts)
+    local cmd = 'bin/luatest test/fixtures/' .. file
+    if opts then
+        cmd = cmd .. ' ' .. opts
+    end
+    return os.execute(cmd)
 end
 
 g.test_executable_pass = function()
@@ -42,6 +46,10 @@ end
 
 g.test_executable_error = function()
     t.assert_equals(run_file('error.lua'), 256) -- luajit multiplies result by 256
+end
+
+g.test_repeat = function()
+    t.assert_equals(run_file('flaky.lua', '-r 2'), 256)
 end
 
 g.test_run_without_capture = function()


### PR DESCRIPTION
"luatest -r 2" etc would terminate with
"attempt to concatenate field 'test_iteration' (a nil value)"
if some test would fail not on the first iteration.

Broken in 940b4c1
(Tue Dec 3 11:32:59 2019 +0300).

Reproducer (launch with "-r 2"):
```
local t = require('luatest')

g_flaky = t.group('flaky')

local counter = 1
g_flaky.test_flaky = function()
    t.fail_if(counter > 1, 'Boo!')
    counter = counter + 1
end
```

I didn't forget about

- [x] Tests
- [ ] Changelog
- [ ] Documentation
