### PR TITLE
Add line with tap version to the tap output

### DIFF
--- a/luatest/output/tap.lua
+++ b/luatest/output/tap.lua
@@ -2,6 +2,7 @@
 local Output = require('luatest.output.generic'):new_class()
 
 function Output.mt:start_suite()
+    print("TAP version 13")
     print("1.."..self.result.selected_count)
     print('# Started on ' .. os.date(nil, self.result.start_time))
 end


### PR DESCRIPTION
Tap protocol is used to the first line as a line with the version.