### PR TITLE
Add pull/push workflow for translations

### DIFF
--- a/.github/workflows/destroy-deployment.yml
+++ b/.github/workflows/destroy-deployment.yml
@@ -1,0 +1,24 @@
+name: Destroy-deployments
+
+on:
+  pull_request:
+    paths:
+      - 'doc/**/*'
+    types:
+      - closed
+jobs:
+  destroy-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
+
+      - name: Remove dev server deployment at ${{env.DEPLOYMENT_NAME}}
+        uses: strumwolf/delete-deployment-environment@v2
+        with:
+          token: "${{ secrets.TARANTOOLBOT_TOKEN }}"
+          environment: "translation-${{env.BRANCH_NAME}}"

--- a/.github/workflows/pull-translation.yml
+++ b/.github/workflows/pull-translation.yml
@@ -1,0 +1,51 @@
+name: Pull translations
+
+on:
+  workflow_dispatch:
+    branches:
+      - '!master'
+jobs:
+  pull-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.TARANTOOLBOT_TOKEN}}
+
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v2
+
+      - name: Setup Python requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r doc/requirements.txt
+
+      - name: Pull translations from Crowdin
+        uses: crowdin/github-action@1.0.21
+        with:
+          config: 'doc/crowdin.yaml'
+          upload_sources: false
+          upload_translations: false
+          push_translations: false
+          download_translations: true
+          download_language: 'ru'
+          crowdin_branch_name: ${{env.BRANCH_NAME}}
+          debug_mode: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          CROWDIN_PERSONAL_TOKEN: ${{secrets.CROWDIN_PERSONAL_TOKEN}}
+
+      - name: Cleanup translation files
+        run: |
+          sudo chown -R runner:docker doc/locale/ru/LC_MESSAGES
+          python doc/cleanup.py po
+
+      - name: Commit translation files
+        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
+          commit_message: "Update translations"
+          file_pattern: "*.po"

--- a/.github/workflows/push-translation.yml
+++ b/.github/workflows/push-translation.yml
@@ -1,0 +1,55 @@
+name: Push translation sources
+
+on:
+  pull_request:
+    paths:
+      - 'doc/**/*'
+jobs:
+  push-translation-sources:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
+
+      - name: Start translation service deployment
+        uses: bobheadxi/deployments@v0.5.2
+        id: translation
+        with:
+          step: start
+          token: ${{secrets.GITHUB_TOKEN}}
+          env: translation-${{env.BRANCH_NAME}}
+          ref: ${{github.head_ref}}
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v2
+
+      - name: Setup Python requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r doc/requirements.txt
+
+      - name: Build pot files
+        run: python -m sphinx . doc/locale/en -c doc -b gettext
+
+      - name: Push POT files to crowdin
+        uses: crowdin/github-action@1.0.21
+        with:
+          upload_sources: true
+          upload_translations: false
+          crowdin_branch_name: ${{env.BRANCH_NAME}}
+          config: 'doc/crowdin.yaml'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          CROWDIN_PERSONAL_TOKEN: ${{secrets.CROWDIN_PERSONAL_TOKEN}}
+
+      - name: update deployment status
+        uses: bobheadxi/deployments@v0.5.2
+        with:
+          step: finish
+          token: ${{secrets.GITHUB_TOKEN}}
+          status: ${{job.status}}
+          deployment_id: ${{steps.translation.outputs.deployment_id}}
+          env_url: https://crowdin.com/project/tarantool-luatest/ru#/${{env.BRANCH_NAME}}

--- a/.github/workflows/upload-translations.yml
+++ b/.github/workflows/upload-translations.yml
@@ -1,0 +1,38 @@
+name: Update translations on the main branch
+
+on:
+  push:
+    paths:
+      - 'doc/**/*'
+    branches:
+      - master
+jobs:
+  autocommit-pot-files:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python environment
+      uses: actions/setup-python@v2
+
+    - name: Setup Python requirements
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r doc/requirements.txt
+
+    - name: Build pot files
+      run: python -m sphinx . doc/locale/en -c doc -b gettext
+
+    - name: Push Pot-files to crowdin
+      uses: crowdin/github-action@1.1.0
+      with:
+        config: 'doc/crowdin.yaml'
+        upload_sources: true
+        upload_translations: true
+        import_eq_suggestions: true
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        CROWDIN_PERSONAL_TOKEN: ${{secrets.CROWDIN_PERSONAL_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .luarocks
 .rocks
 .idea
-/doc
 
 /tmp/*
 !/tmp/.keep
@@ -17,3 +16,5 @@ build
 build.luarocks
 Testing
 /rst/
+doc/output
+doc/locale/en/

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,20 @@
+[![Crowdin](https://badges.crowdin.net/tarantool-luatest/localized.svg)](https://crowdin.com/project/tarantool-luatest)
+
+# Luatest documentation
+Part of Tarantool documentation, published to 
+https://www.tarantool.io/en/doc/latest/reference/reference_rock/luatest/luatest_overview/
+
+## Create pot files from rst
+```bash
+python -m sphinx . doc/locale/en -c doc -b gettext
+```
+
+## Create/update po from pot files
+```bash
+sphinx-intl update -p doc/locale/en -d doc/locale -l ru
+```
+
+## Build documentation to doc/output
+```bash
+python -m sphinx . doc/output -c doc
+```

--- a/doc/cleanup.py
+++ b/doc/cleanup.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python3
+import argparse
+from glob import glob
+from polib import pofile, POFile, _BaseFile
+
+parser = argparse.ArgumentParser(description='Cleanup PO and POT files')
+parser.add_argument('extension', type=str, choices=['po', 'pot', 'both'],
+                    help='cleanup files with extension: po, pot or both')
+
+
+class PoFile(POFile):
+
+    def __unicode__(self):
+        return _BaseFile.__unicode__(self)
+
+    def metadata_as_entry(self):
+        class M:
+            def __unicode__(self, _):
+                return ''
+        return M()
+
+
+def cleanup_files(extension):
+    mask = f'**/*.{extension}'
+    for file_path in glob(mask, recursive=True):
+        print(f'cleanup {file_path}')
+        po_file: POFile = pofile(file_path, klass=PoFile)
+        po_file.header = ''
+        po_file.metadata = {}
+        po_file.metadata_is_fuzzy = False
+
+        for item in po_file:
+            item.occurrences = None
+
+        po_file.save()
+
+
+if __name__ == "__main__":
+
+    args = parser.parse_args()
+
+    if args.extension in ['po', 'both']:
+        cleanup_files('po')
+
+    if args.extension in ['pot', 'both']:
+        cleanup_files('pot')

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,23 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(''))
+
+master_doc = 'README'
+
+source_suffix = '.rst'
+
+project = u'Luatest'
+
+exclude_patterns = [
+    'doc/locale',
+    'doc/output',
+    'doc/README.md',
+    'doc/cleanup.py',
+    'doc/requirements.txt',
+]
+
+language = 'en'
+locale_dirs = ['./doc/locale']
+gettext_compact = False
+gettext_location = True

--- a/doc/crowdin.yaml
+++ b/doc/crowdin.yaml
@@ -1,0 +1,24 @@
+# https://support.crowdin.com/configuration-file/
+# https://support.crowdin.com/cli-tool-v3/#configuration
+
+"project_id" : "463362"
+"base_path" : "doc/locale"
+"base_url": "https://crowdin.com"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+
+
+"preserve_hierarchy": true
+
+files: [
+ {
+  "source" : "/en/**/*.pot",
+  "translation" : "/%locale_with_underscore%/LC_MESSAGES/**/%file_name%.po",
+  "update_option" : "update_as_unapproved",
+
+  "languages_mapping" : {
+    "locale_with_underscore" : {
+      "ru" : "ru",
+     }
+  },
+ }
+]

--- a/doc/locale/ru/LC_MESSAGES/README.po
+++ b/doc/locale/ru/LC_MESSAGES/README.po
@@ -1,0 +1,424 @@
+
+msgid "Overview"
+msgstr ""
+
+msgid ""
+"Tool for testing tarantool applications. (`Build Status <https://travis-"
+"ci.com/tarantool/luatest.svg?branch=master)](https://travis-"
+"ci.com/tarantool/luatest>`_)."
+msgstr ""
+
+msgid "Highlights:"
+msgstr ""
+
+msgid "executable to run tests in directory or specific files,"
+msgstr ""
+
+msgid "before/after suite hooks,"
+msgstr ""
+
+msgid "before/after test group hooks,"
+msgstr ""
+
+msgid "`output capturing <Capturing output_>`_,"
+msgstr ""
+
+msgid "`helpers <Test helpers_>`_ for testing tarantool applications,"
+msgstr ""
+
+msgid "`luacov integration <luacov integration_>`_."
+msgstr ""
+
+msgid "Requirements"
+msgstr ""
+
+msgid ""
+"Tarantool (it requires tarantool-specific ``fio`` module and ``ffi`` from "
+"LuaJIT)."
+msgstr ""
+
+msgid "Installation"
+msgstr ""
+
+msgid "Usage"
+msgstr ""
+
+msgid "Define tests."
+msgstr ""
+
+msgid "Run them."
+msgstr ""
+
+msgid ""
+"Luatest automatically requires ``test/helper.lua`` file if it's present. You"
+" can configure luatest or run any bootstrap code there."
+msgstr ""
+
+msgid ""
+"See the `getting-started example <https://github.com/tarantool/cartridge-"
+"cli/tree/master/examples/getting-started-app/test>`_ in cartridge-cli repo."
+msgstr ""
+
+msgid "Tests order"
+msgstr ""
+
+msgid ""
+"Use the ``--shuffle`` option to tell luatest how to order the tests. The "
+"available ordering schemes are ``group``, ``all`` and ``none``."
+msgstr ""
+
+msgid "``group`` shuffles tests within the groups."
+msgstr ""
+
+msgid ""
+"``all`` randomizes execution order across all available tests. Be careful: "
+"``before_all/after_all`` hooks run always when test group is changed, so it "
+"may run multiple time."
+msgstr ""
+
+msgid ""
+"``none`` is the default, which executes examples within the group in the "
+"order they are defined (eventually they are ordered by functions line "
+"numbers)."
+msgstr ""
+
+msgid ""
+"With ``group`` and ``all`` you can also specify a ``seed`` to reproduce "
+"specific order."
+msgstr ""
+
+msgid "To change default order use:"
+msgstr ""
+
+msgid "List of luatest functions"
+msgstr ""
+
+msgid "**Assertions**"
+msgstr ""
+
+msgid "``assert (value[, message])``"
+msgstr ""
+
+msgid "Check that value is truthy."
+msgstr ""
+
+msgid "``assert_almost_equals (actual, expected, margin[, message])``"
+msgstr ""
+
+msgid "Check that two floats are close by margin."
+msgstr ""
+
+msgid "``assert_covers (actual, expected[, message])``"
+msgstr ""
+
+msgid "Checks that actual map includes expected one."
+msgstr ""
+
+msgid "``assert_lt (left, right[, message])``"
+msgstr ""
+
+msgid "Compare numbers."
+msgstr ""
+
+msgid "``assert_le (left, right[, message])``"
+msgstr ""
+
+msgid "``assert_gt (left, right[, message])``"
+msgstr ""
+
+msgid "``assert_ge (left, right[, message])``"
+msgstr ""
+
+msgid "``assert_equals (actual, expected[, message[, deep_analysis]])``"
+msgstr ""
+
+msgid "Check that two values are equal."
+msgstr ""
+
+msgid "``assert_error (fn, ...)``"
+msgstr ""
+
+msgid "Check that calling fn raises an error."
+msgstr ""
+
+msgid "``assert_error_msg_contains (expected_partial, fn, ...)``"
+msgstr ""
+
+msgid "``assert_error_msg_content_equals (expected, fn, ...)``"
+msgstr ""
+
+msgid "Strips location info from message text."
+msgstr ""
+
+msgid "``assert_error_msg_equals (expected, fn, ...)``"
+msgstr ""
+
+msgid "Checks full error: location and text."
+msgstr ""
+
+msgid "``assert_error_msg_matches (pattern, fn, ...)``"
+msgstr ""
+
+msgid "``assert_eval_to_false (value[, message])``"
+msgstr ""
+
+msgid "Alias for assert_not."
+msgstr ""
+
+msgid "``assert_eval_to_true (value[, message])``"
+msgstr ""
+
+msgid "Alias for assert."
+msgstr ""
+
+msgid "``assert_items_include (actual, expected[, message])``"
+msgstr ""
+
+msgid "Checks that actual includes all items of expected."
+msgstr ""
+
+msgid "``assert_is (actual, expected[, message])``"
+msgstr ""
+
+msgid "Check that values are the same."
+msgstr ""
+
+msgid "``assert_is_not (actual, expected[, message])``"
+msgstr ""
+
+msgid "Check that values are not the same."
+msgstr ""
+
+msgid "``assert_items_equals (actual, expected[, message])``"
+msgstr ""
+
+msgid "Checks equality of tables regardless of the order of elements."
+msgstr ""
+
+msgid "``assert_nan (value[, message])``"
+msgstr ""
+
+msgid "``assert_not (value[, message])``"
+msgstr ""
+
+msgid "Check that value is falsy."
+msgstr ""
+
+msgid "``assert_not_almost_equals (actual, expected, margin[, message])``"
+msgstr ""
+
+msgid "Check that two floats are not close by margin"
+msgstr ""
+
+msgid "``assert_not_covers (actual, expected[, message])``"
+msgstr ""
+
+msgid "Checks that map does not contain the other one."
+msgstr ""
+
+msgid "``assert_not_equals (actual, expected[, message])``"
+msgstr ""
+
+msgid "Check that two values are not equal."
+msgstr ""
+
+msgid "``assert_not_nan (value[, message])``"
+msgstr ""
+
+msgid ""
+"``assert_not_str_contains (actual, expected[, is_pattern[, message]])``"
+msgstr ""
+
+msgid "Case-sensitive strings comparison."
+msgstr ""
+
+msgid "``assert_not_str_icontains (value, expected[, message])``"
+msgstr ""
+
+msgid "Case-insensitive strings comparison."
+msgstr ""
+
+msgid "``assert_str_contains (value, expected[, is_pattern[, message]])``"
+msgstr ""
+
+msgid "``assert_str_icontains (value, expected[, message])``"
+msgstr ""
+
+msgid ""
+"``assert_str_matches (value, pattern[, start=1[, final=value:len() [, "
+"message]]])``"
+msgstr ""
+
+msgid "Verify a full match for the string."
+msgstr ""
+
+msgid "``assert_type (value, expected_type[, message])``"
+msgstr ""
+
+msgid "Check value's type."
+msgstr ""
+
+msgid "**Flow control**"
+msgstr ""
+
+msgid "``fail (message)``"
+msgstr ""
+
+msgid "Stops a test due to a failure."
+msgstr ""
+
+msgid "``fail_if (condition, message)``"
+msgstr ""
+
+msgid "Stops a test due to a failure if condition is met."
+msgstr ""
+
+msgid "``skip (message)``"
+msgstr ""
+
+msgid "Skip a running test."
+msgstr ""
+
+msgid "``skip_if (condition, message)``"
+msgstr ""
+
+msgid "Skip a running test if condition is met."
+msgstr ""
+
+msgid "``success ()``"
+msgstr ""
+
+msgid "Stops a test with a success."
+msgstr ""
+
+msgid "``success_if (condition)``"
+msgstr ""
+
+msgid "Stops a test with a success if condition is met."
+msgstr ""
+
+msgid "**Suite and groups**"
+msgstr ""
+
+msgid "``after_suite (fn)``"
+msgstr ""
+
+msgid "Add after suite hook."
+msgstr ""
+
+msgid "``before_suite (fn)``"
+msgstr ""
+
+msgid "Add before suite hook."
+msgstr ""
+
+msgid "``group (name)``"
+msgstr ""
+
+msgid "Create group of tests."
+msgstr ""
+
+msgid "Capturing output"
+msgstr ""
+
+msgid ""
+"By default runner captures all stdout/stderr output and shows it only for "
+"failed tests. Capturing can be disabled with ``-c`` flag."
+msgstr ""
+
+msgid "Test helpers"
+msgstr ""
+
+msgid ""
+"There are helpers to run tarantool applications and perform basic "
+"interaction with it. If application follows configuration conventions it is "
+"possible to use options to configure server instance and helpers at the same"
+" time. For example ``http_port`` is used to perform http request in tests "
+"and passed in ``TARANTOOL_HTTP_PORT`` to server process."
+msgstr ""
+
+msgid ""
+"``luatest.Process:start(path, args, env)`` provides low-level interface to "
+"run any other application."
+msgstr ""
+
+msgid "There are several small helpers for common actions:"
+msgstr ""
+
+msgid "luacov integration"
+msgstr ""
+
+msgid ""
+"Install `luacov <https://github.com/keplerproject/luacov>`_ with "
+"``tarantoolctl rocks install luacov``"
+msgstr ""
+
+msgid "Configure it with ``.luacov`` file"
+msgstr ""
+
+msgid "Clean old reports ``rm -f luacov.*.out*``"
+msgstr ""
+
+msgid "Run luatest with ``--coverage`` option"
+msgstr ""
+
+msgid "Generate report with ``.rocks/bin/luacov .``"
+msgstr ""
+
+msgid "Show summary with ``grep -A999 '^Summary' luacov.report.out``"
+msgstr ""
+
+msgid ""
+"When running integration tests with coverage collector enabled, luatest "
+"automatically starts new tarantool instances with luacov enabled. So "
+"coverage is collected from all the instances. However this has some "
+"limitations:"
+msgstr ""
+
+msgid "It works only for instances started with ``Server`` helper."
+msgstr ""
+
+msgid ""
+"Process command should be executable lua file or tarantool with script "
+"argument."
+msgstr ""
+
+msgid ""
+"Instance must be stopped with ``server:stop()``, because this is the point "
+"where stats are saved."
+msgstr ""
+
+msgid "Don't save stats concurrently to prevent corruption."
+msgstr ""
+
+msgid "Development"
+msgstr ""
+
+msgid "Check out the repo."
+msgstr ""
+
+msgid "Prepare makefile with ``cmake .``."
+msgstr ""
+
+msgid "Install dependencies with ``make bootstrap``."
+msgstr ""
+
+msgid "Run it with ``make lint`` before committing changes."
+msgstr ""
+
+msgid "Run tests with ``bin/luatest``."
+msgstr ""
+
+msgid "Contributing"
+msgstr ""
+
+msgid ""
+"Bug reports and pull requests are welcome on at "
+"https://github.com/tarantool/luatest."
+msgstr ""
+
+msgid "License"
+msgstr ""
+
+msgid "MIT"
+msgstr ""

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==4.0.2
+sphinx-intl==2.0.1
+polib==1.1.1


### PR DESCRIPTION
Documentation sources are .rst files where a tech writer or a developer writes documentation. As soon as we have two languages supported on our website we need to maintain translated 100% of the documentation. For translation, we use Crowdin - saas solution for translating any texts.  
While a new PR with changes in .rst is opened, the translations for these changes are preparing by translators in Crowdin.  
When the translations are ready we can run __Pull translations__ job to download and commit translations into the PR branch.  
This diagram shows how the process works:
![crowdin-time-diagram](https://user-images.githubusercontent.com/23726173/124887107-8c53ca00-dfdd-11eb-9552-5154e469fa33.png)

- add cleanup.py for re-arranging .po files and initial re-arranged .po files
- push-translation.yml push translation sources to Crowdin on pull request when .rst is changed, create a deployment with a link to Crowdin translations
- pull-translation.yml for getting translations from Crowdin on demand when translation is ready and auto-commit them into the same PR branch
- upload-translations.yml for upload translations to the master Crowdin branch from the git master branch
- destroy deployment with a link to Crowdin translations when the translations (in PR) are merged

Closes #139
