### PR TITLE
Make use of setup-tarantool github action

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -11,17 +11,17 @@ jobs:
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
     strategy:
       matrix:
-        tarantool-version: ["1.10", "2.6", "2.7", "2.8"]
+        tarantool: ["1.10", "2.6", "2.7", "2.8"]
       fail-fast: false
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@master
+      - uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: '${{ matrix.tarantool }}'
 
       - name: Install requirements for community
         run: |
-          curl -L https://tarantool.io/installer.sh | sudo VER=${{ matrix.tarantool-version }} bash
-          sudo apt install -y tarantool-dev
-          tarantool --version
           cmake .
           make bootstrap
 


### PR DESCRIPTION
It's common nowadays to use `tarantool/setup-tarantool` Github Action. It makes CI faster by caching installed deb packages.

I didn't forget about

- [x] Tests
- [x] ~~Changelog~~
- [x] ~~Documentation~~
