### PR TITLE
Implement group parametrization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Repeat `_each` and `_test` hooks when `--repeat` is specified
+- Add group parametrization
 
 ## 0.5.4
 

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,18 @@ Define tests.
     g.test_example_2 = function() ... end
     g.test_example_m = function() ... end
 
+    -- Define parametrized groups
+    local pg = t.group('pgroup', t.helpers.matrix({param_1 = {1, 2}, param_2 = {3, 4}}))
+    pg.test_example_1 = function(cg) ... end
+    -- type(cg.params.param_1) == 'number'
+    pg.test_example_n = function(cg) ... end
+
+    -- Hooks can be specified for one parameter
+    pg.before_all(function() ... end)
+    pg.before_each({param_1 = 1}, function() ... end)
+    pg.after_each({param_2 = 3}, function() ... end)
+    pg.after_test('test_example_1', {param_1 = 2, param_2 = 4}, function() ... end)
+
 
 Run them.
 
@@ -231,6 +243,58 @@ Capturing output
 
 By default runner captures all stdout/stderr output and shows it only for failed tests.
 Capturing can be disabled with ``-c`` flag.
+
+.. _parametrization:
+
+---------------------------------
+Parametrization
+---------------------------------
+
+Test group can be parametrized.
+
+.. code-block:: Lua
+
+    local g = t.group('pgroup', {{a = 1, b = 4}, {a = 2, b = 3}})
+
+    g.test_params = function(cg)
+        ...
+        local param_a_val = cg.params.a
+        local param_b_val = cg.params.b
+        ...
+    end
+
+Group can be parametrized with a matrix of parameters using helper.
+
+.. code-block:: Lua
+
+    local g = t.group('pgroup', t.helpers.matrix({a = {1, 2}, b = {3, 4}}))
+
+
+Each test will be performed for every params combination. Hooks will work as usual
+unless there are specified params. The order of execution in the hook group is
+determined by the order of declaration.
+
+.. code-block:: Lua
+
+    -- called before every test
+    g.before_each(function(cg) ... end)
+
+    -- called before tests when a == 1
+    g.before_each({a = 1}, function(cg) ... end)
+
+    -- called only before the test when a == 1 and b == 3
+    g.before_each({a = 1, b = 3}, function(cg) ... end)
+
+    -- called before test named 'test_something' when a == 1
+    g.before_test('test_something', {a = 1}, function(cg) ... end)
+
+    --etc
+
+Test with specific params can be called from command line.
+
+.. code-block:: Bash
+
+    luatest path-to-file pgroup.a:1.b:3.test_params
 
 .. _test-helpers:
 

--- a/luatest/helpers.lua
+++ b/luatest/helpers.lua
@@ -80,10 +80,12 @@ end
 --
 --     helpers.matrix({a = {1, 2}, b = {3, 4}})
 --
---     {{a = 1, b = 3},
---      {a = 2, b = 3},
---      {a = 1, b = 4},
---      {a = 2, b = 4}}
+--     {
+--       {a = 1, b = 3},
+--       {a = 2, b = 3},
+--       {a = 1, b = 4},
+--       {a = 2, b = 4},
+--     }
 --
 -- @tab parameters_values
 function helpers.matrix(parameters_values)

--- a/luatest/helpers.lua
+++ b/luatest/helpers.lua
@@ -75,4 +75,41 @@ function helpers.retrying(config, fn, ...)
     end
 end
 
+--- Return all combinations of parameters.
+-- Accepts params' names and thier every possible value.
+--
+--     helpers.matrix({a = {1, 2}, b = {3, 4}})
+--
+--     {{a = 1, b = 3},
+--      {a = 2, b = 3},
+--      {a = 1, b = 4},
+--      {a = 2, b = 4}}
+--
+-- @tab parameters_values
+function helpers.matrix(parameters_values)
+    local combinations = {}
+
+    local params_names = {}
+    for name, _ in pairs(parameters_values) do
+        table.insert(params_names, name)
+    end
+    table.sort(params_names)
+
+    local function combinator(_params, ind, ...)
+        if ind < 1 then
+            local combination = {}
+            for _, entry in ipairs({...}) do
+                combination[entry[1]] = entry[2]
+            end
+            table.insert(combinations, combination)
+        else
+            local name = params_names[ind]
+            for i=1,#(_params[name]) do combinator(_params, ind - 1, {name, _params[name][i]}, ...) end
+        end
+    end
+
+    combinator(parameters_values, #params_names)
+    return combinations
+end
+
 return helpers

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -17,6 +17,7 @@ luatest.Server = require('luatest.server')
 
 local Group = require('luatest.group')
 local hooks = require('luatest.hooks')
+local parametrizer = require('luatest.parametrizer')
 
 --- Add before suite hook.
 --
@@ -36,13 +37,26 @@ luatest.groups = {}
 -- @string[opt] name
 -- @return Group object
 -- @see luatest.group
-function luatest.group(name)
+function luatest.group(name,  params)
     local group = Group:new(name)
     name = group.name
     if luatest.groups[name] then
         error('Test group already exists: ' .. name ..'.')
     end
-    luatest.groups[name] = group
+
+    if params then
+        parametrizer.parametrize(group, params)
+    end
+
+    -- Register all parametrized groups
+    if group.pgroups then
+        for _, pgroup in ipairs(group.pgroups) do
+            luatest.groups[pgroup.name] = pgroup
+        end
+    else
+        luatest.groups[name] = group
+    end
+
     return group
 end
 

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -35,6 +35,7 @@ luatest.groups = {}
 --- Create group of tests.
 --
 -- @string[opt] name
+-- @table[opt] params
 -- @return Group object
 -- @see luatest.group
 function luatest.group(name,  params)

--- a/luatest/parametrizer.lua
+++ b/luatest/parametrizer.lua
@@ -1,0 +1,89 @@
+local checks = require('checks')
+
+local Group = require('luatest.group')
+local pp = require('luatest.pp')
+
+local export = {}
+
+local function get_group_name(params)
+    local params_names = {}
+    for name, _ in pairs(params) do
+        table.insert(params_names, name)
+    end
+    table.sort(params_names)
+
+    for ind, param_name in ipairs(params_names) do
+        params_names[ind] = param_name .. ':' .. pp.tostring(params[param_name])
+    end
+    return table.concat(params_names, ".")
+end
+
+local function redefine_hooks(group, hooks_type)
+    -- Super group shares its hooks with pgroups
+    for _, pgroup in ipairs(group.pgroups) do
+        pgroup[hooks_type .. '_hooks'] = group[hooks_type .. '_hooks']
+    end
+end
+
+local function redefine_pgroups_hooks(group)
+    redefine_hooks(group, 'before_each')
+    redefine_hooks(group, 'after_each')
+    redefine_hooks(group, 'before_all')
+    redefine_hooks(group, 'after_all')
+
+    redefine_hooks(group, 'before_test')
+    redefine_hooks(group, 'after_test')
+end
+
+local function redirect_index(group)
+    local super_group_mt = getmetatable(group)
+    if super_group_mt.__newindex then
+        return
+    end
+
+    super_group_mt.__newindex = function(_group, key, value)
+        if _group.pgroups then
+            for _, pgroup in ipairs(_group.pgroups) do
+                pgroup[key] = value
+            end
+        else
+            rawset(_group, key, value)
+        end
+    end
+end
+
+function export.parametrize(object, parameters_combinations)
+    checks('table', 'table')
+    -- Validate params' name and values
+    local counter = 0
+    for _, _ in pairs(parameters_combinations) do
+        counter = counter + 1
+        assert(parameters_combinations[counter] ~= nil,
+            'parameters_combinations should be a contiguous array')
+
+        assert(type(parameters_combinations[counter]) == 'table',
+            string.format('parameters_combinations\' entry should be table, got %s',
+                type(parameters_combinations[counter])))
+
+        for parameter_name, _ in pairs(parameters_combinations[counter]) do
+            assert(type(parameter_name) == 'string',
+                string.format('parameter name should be string, got %s', type(parameter_name)))
+        end
+    end
+
+    -- Create a subgroup on every param combination
+    object.pgroups = {}
+    for _, pgroup_params in ipairs(parameters_combinations) do
+        local pgroup_name = get_group_name(pgroup_params)
+        local pgroup = Group:new(object.name .. '.' .. pgroup_name)
+        pgroup.params = pgroup_params
+
+        pgroup.super_group = object
+        table.insert(object.pgroups, pgroup)
+    end
+
+    redirect_index(object)
+    redefine_pgroups_hooks(object)
+end
+
+return export

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -120,4 +120,17 @@ function utils.pattern_filter(patterns, expr)
     return result
 end
 
+function utils.split_test_name(test_name)
+    local test_name_parts = string.split(test_name, '.')
+    return test_name_parts, #test_name_parts
+end
+
+function utils.table_len(t)
+    local counter = 0
+    for _, _ in pairs(t) do
+        counter = counter + 1
+    end
+    return counter
+end
+
 return utils

--- a/test/fixtures/parametrized.lua
+++ b/test/fixtures/parametrized.lua
@@ -1,0 +1,6 @@
+local t = require('luatest')
+local g = t.group('parametrized_fixture', t.helpers.matrix{a = {1, 2, 3}, b = {4, 5, 6}})
+
+g.test_something = function(cg)
+    t.assert_not_equals(cg.params.a, 3)
+end

--- a/test/helpers_test.lua
+++ b/test/helpers_test.lua
@@ -38,3 +38,35 @@ g.test_rescuing_failure = function()
     end)
     t.assert_almost_equals(retry, 6, 1)
 end
+
+g.test_matrix = function()
+    t.assert_equals(t.helpers.matrix({}), {{}})
+    t.assert_equals(t.helpers.matrix({a = {1}}), {{a = 1}})
+    t.assert_equals(t.helpers.matrix({a = {1, 2}}), {{a = 1}, {a = 2}})
+    t.assert_equals(t.helpers.matrix({a = {1}, b = {2}}), {{a = 1, b = 2}})
+
+    t.assert_equals(t.helpers.matrix({a = {1, 3}, b = {{2}, {4}}}), {
+        {a = 1, b = {2}},
+        {a = 3, b = {2}},
+        {a = 1, b = {4}},
+        {a = 3, b = {4}},
+    })
+
+    t.assert_equals(t.helpers.matrix({a = {1, 3}, b = {2, 4}, c = {5, 6}}), {
+        {a = 1, b = 2, c = 5},
+        {a = 3, b = 2, c = 5},
+        {a = 1, b = 4, c = 5},
+        {a = 3, b = 4, c = 5},
+        {a = 1, b = 2, c = 6},
+        {a = 3, b = 2, c = 6},
+        {a = 1, b = 4, c = 6},
+        {a = 3, b = 4, c = 6},
+    })
+
+    t.assert_equals(t.helpers.matrix({{1, 3}, {2, 4}}), {
+        {1, 2},
+        {3, 2},
+        {1, 4},
+        {3, 4},
+    })
+end

--- a/test/parametrization_test.lua
+++ b/test/parametrization_test.lua
@@ -1,0 +1,229 @@
+local t = require('luatest')
+local g = t.group()
+
+local helper = require('test.helper')
+
+g.test_validation = function()
+    t.assert_error_msg_contains(
+        'parameters_combinations should be a contiguous array',
+        function() t.group('parametrized', {[2] = {1, 2}}) end
+    )
+
+    t.assert_error_msg_contains(
+        'parameter name should be string, got function',
+        function() t.group('parametrized', {{[function() end] = 1}}) end
+    )
+
+    t.assert_error_msg_contains(
+        'parameters_combinations\' entry should be table, got string',
+        function() t.group('parametrized', {'params'}) end
+    )
+
+    t.assert_error_msg_contains(
+        'parameters_combinations should be a contiguous array',
+        function() t.group('parametrized', {['name'] = 1}) end
+    )
+
+    t.assert(pcall(function() t.group('parametrized', {{name = 'value'}}) end))
+
+    local pg = t.group('pg', {{name = 'value'}})
+    t.assert_error_msg_contains(
+        'hook should be function, got number',
+        function() pg.after_each(1) end
+    )
+    t.assert_error_msg_contains(
+        'params should be table, got function',
+        function() pg.after_each(function() end, {name = 'value'}) end
+    )
+    t.assert_error_msg_contains(
+        'hook should be function, got number',
+        function() pg.after_each({name = 'value'}, 1) end
+    )
+    t.assert(pcall(function() pg.after_each({name = 'value'}, function() end) end))
+
+    t.assert_error_msg_contains(
+        'test name should be string, got number',
+        function() pg.after_test(1) end
+    )
+    t.assert_error_msg_contains(
+        'test name should be string, got number',
+        function() pg.after_test(1, {name = 'value'}, function() end) end
+    )
+    t.assert_error_msg_contains(
+        'params should be table, got function',
+        function() pg.after_test('test_name', function() end, {name = 'value'}) end
+    )
+    t.assert_error_msg_contains(
+        'hook should be function, got number',
+        function() pg.after_test('test_name', {name = 'value'}, 1) end
+    )
+    t.assert(pcall(function()
+        pg.after_test('test_name', {name = 'value'}, function() end)
+    end))
+end
+
+g.test_index_redirection = function()
+    local counter = 0
+    local result = helper.run_suite(function(lu2)
+        local pg = lu2.group('parametrized', t.helpers.matrix({param1 = {1, 2, 3}, param2 = {4, 5}}))
+        pg.test_counter_inc = function()
+            counter = counter + 1
+        end
+    end)
+
+    t.assert_equals(result , 0)
+    t.assert_equals(counter, 6)
+end
+
+g.test_params = function()
+    local expected = {
+        ['a.b:1.c:{3}'] = 3,
+        ['a.b:1.c:{4}'] = 4,
+        ['a.b:2.c:{3}'] = 6,
+        ['a.b:2.c:{4}'] = 8,
+    }
+
+    local actual = {}
+    local result = helper.run_suite(function(lu2)
+        local pg = lu2.group('a', t.helpers.matrix({b = {1, 2}, c = {{3}, {4}}}))
+        pg.test_1 = function(cg)
+            actual[cg.name] = cg.params.b * cg.params.c[1]
+        end
+    end)
+
+    t.assert_equals(result , 0)
+    t.assert_equals(actual, expected)
+end
+
+g.test_hooks = function()
+    local expected = {
+        "before_all_1",
+        "before_all1_1",
+        "before_each_1",
+        "before_each1_1",
+        "test1_1",
+        "after_each_1",
+        "after_all_1",
+        "before_all_2",
+        "before_each_2",
+        "test1_2",
+        "after_each2_2",
+        "after_each_2",
+        "after_all2_2",
+        "after_all_2",
+    }
+
+    local actual = {}
+    local result = helper.run_suite(function(lu2)
+        local pg = lu2.group('super', t.helpers.matrix({b = {1, 2}}))
+
+        pg.before_all(function(cg) print(g.name) table.insert(actual, 'before_all_' .. cg.params.b) end)
+        pg.before_all({b = 1}, function(cg) table.insert(actual, 'before_all1_' .. cg.params.b) end)
+
+        pg.before_each(function(cg) table.insert(actual, 'before_each_' .. cg.params.b) end)
+        pg.before_each({b = 1}, function(cg) table.insert(actual, 'before_each1_' .. cg.params.b) end)
+
+        pg.after_each({b = 2}, function(cg) table.insert(actual, 'after_each2_' .. cg.params.b) end)
+        pg.after_each(function(cg) table.insert(actual, 'after_each_' .. cg.params.b) end)
+
+        pg.after_all({b = 2}, function(cg) table.insert(actual, 'after_all2_' .. cg.params.b) end)
+        pg.after_all(function(cg) table.insert(actual, 'after_all_' .. cg.params.b) end)
+
+        pg.test_1 = function(cg)
+            table.insert(actual, 'test1_' .. cg.params.b)
+        end
+    end)
+
+    t.assert_equals(result, 0)
+    t.assert_equals(actual, expected)
+
+end
+
+g.test_named_hooks = function()
+    local expected = {
+        "before_test_1_1",
+        "before_test_1_b_1_1",
+        "test1_1",
+        "test2_1",
+        "after_test_2__1",
+        "before_test_1_2",
+        "test1_2",
+        "test2_2",
+        "after_test_2_b_2_2",
+        "after_test_2__2",
+    }
+
+    local actual = {}
+    local result = helper.run_suite(function(lu2)
+        local pg = lu2.group('super', t.helpers.matrix({b = {1, 2}}))
+
+        pg.before_test('test_1', function(cg) table.insert(actual, 'before_test_1_' .. cg.params.b) end)
+        pg.before_test('test_1', {b = 1}, function(cg) table.insert(actual, 'before_test_1_b_1_' .. cg.params.b) end)
+        pg.after_test('test_2', {b = 2}, function(cg) table.insert(actual, 'after_test_2_b_2_' .. cg.params.b) end)
+        pg.after_test('test_2', function(cg) table.insert(actual, 'after_test_2__' .. cg.params.b) end)
+        pg.test_1 = function(cg)
+            table.insert(actual, 'test1_' .. cg.params.b)
+        end
+        pg.test_2 = function(cg)
+            table.insert(actual, 'test2_' .. cg.params.b)
+        end
+    end)
+
+    t.assert_equals(result, 0)
+    t.assert_equals(actual, expected)
+end
+
+g.test_fixed_param_hooks = function()
+    local expected = {
+        "before_each_b!:1_c:4",
+        "test_1_b:1_c:4",
+        "before_each_b!:1_c:3",
+        "test_1_b:1_c:3",
+        "after_each_b:1_c!:3",
+        "before_test_b!:2_c!:4",
+        "test_1_b:2_c:4",
+        "test_1_b:2_c:3",
+        "after_each_b:2_c!:3",
+    }
+
+    local actual = {}
+    local result = helper.run_suite(function(lu2)
+        local pg = lu2.group('super', t.helpers.matrix({b = {1, 2}, c = {{v = 3}, {l = 4}}}))
+
+        pg.before_each({b = 1}, function(cg)
+            table.insert(actual, "before_each_b!:1_c:".. (cg.params.c.v or cg.params.c.l))
+        end)
+
+        pg.after_each({c = {v = 3}}, function(cg)
+            table.insert(actual, "after_each_b:".. cg.params.b .."_c!:3")
+        end)
+
+        pg.before_test('test_1', {b = 2, c = {l = 4}}, function(cg)
+            table.insert(actual, "before_test_b!:".. cg.params.b .."_c!:".. (cg.params.c.v or cg.params.c.l))
+        end)
+
+        pg.before_each({b = 3}, function() table.insert(actual, 'will never happen') end)
+        pg.before_each({c = {v = 3, l = 4}}, function() table.insert(actual, 'will never happen') end)
+
+        pg.test_1 = function(cg) table.insert(actual,
+            string.format("test_1_b:%s_c:%s", cg.params.b, cg.params.c.v or cg.params.c.l))
+        end
+    end)
+
+    t.assert_equals(result, 0)
+    t.assert_equals(actual, expected)
+end
+
+g.test_cmd = function()
+    local function run_param_test(params)
+        local cmd = './bin/luatest'
+        local fixture = './test/fixtures/parametrized.lua'
+        cmd = cmd .. ' ' .. fixture .. ' '
+        cmd = cmd .. 'parametrized_fixture.' .. params
+        cmd = cmd .. '.test_something'
+        return os.execute(cmd)
+    end
+
+    t.assert_equals(run_param_test('a:1.b:4'), 0)
+    t.assert_equals(run_param_test('a:3.b:4'), 256)
+end


### PR DESCRIPTION
Implement group parametrization

```lua
  -- Define parametrized groups
  local pg = t.group('pgroup', t.helpers.matrix({a = {1, 2}, b = {3, 4}}))
  pg.test_example_1 = function(cg) ... end
  -- type(cg.params.a) == 'number'
  pg.test_example_n = function(cg) ... end

  -- Hooks can be specified for one parameter
  pg.before_all(function() ... end)
  pg.before_each({a = 1}, function() ... end)
  pg.after_each({b = 3}, function() ... end)
  pg.after_test('test_example_1', {a = 2, b = 4}, function() ... end)
```

Test with specified params can be started from command line

```
luatest pgroup.a:2.b:3.test_example_1
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #116 
