### PR TITLE
Add server:exec method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Repeat `_each` and `_test` hooks when `--repeat` is specified.
 - Add group parametrization.
+- Add new `Server:exec()` function which runs a Lua function remotely.
 
 ## 0.5.4
 

--- a/README.rst
+++ b/README.rst
@@ -381,6 +381,7 @@ to server process.
     server:connect_net_box()
     server:eval('return do_something(...)', {arg1, arg2})
     server:call('function_name', {arg1, arg2})
+    server:exec(function() return box.info() end)
     server:stop()
 
 ``luatest.Process:start(path, args, env)`` provides low-level interface to run any other application.

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -133,4 +133,14 @@ function utils.table_len(t)
     return counter
 end
 
+function utils.upvalues(fn)
+    local ret = {}
+    for i = 1, debug.getinfo(fn, 'u').nups do
+        ret[i] = debug.getupvalue(fn, i)
+    end
+
+    return ret
+end
+
+
 return utils


### PR DESCRIPTION
Add new `Server:exec()` function which runs a Lua function remotely.

Usage:

```lua
local vclock = server:exec(function()
    return box.info.vclock
end)
```

```lua
local sum = server:exec(function(a, b)
    return a + b
end, {1, 2})
-- sum == 3
```

```lua
server:exec(function()
    local t = require('luatest')
    t.assert_equals(math.pi, 3)
end)
-- mytest.lua:12: expected: 3, actual: 3.1415926535898
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #173 
