### PR TITLE
Fix flaky server.test_unix_socket

### DIFF
--- a/test/server_instance.lua
+++ b/test/server_instance.lua
@@ -6,12 +6,9 @@ local workdir = os.getenv('TARANTOOL_WORKDIR')
 local listen = os.getenv('TARANTOOL_LISTEN')
 local http_port = os.getenv('TARANTOOL_HTTP_PORT')
 
-box.cfg({
-    work_dir = workdir,
-    listen = listen
-})
-
-box.schema.user.grant('guest', 'read,write,execute', 'universe', nil, {if_not_exists=true})
+box.cfg({work_dir = workdir})
+box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists=true})
+box.cfg({listen = listen})
 
 local httpd = require('http.server').new('0.0.0.0', http_port)
 


### PR DESCRIPTION
Due to a race, sometimes it connects to the server before the proper permissions are granted. It results in the error: `Execute access to universe '' is denied for user 'guest'`

This patch fixes the race by granting permissions prior to listening

I didn't forget about

- [x] Tests
- [x] ~~Changelog~~
- [x] ~~Documentation~~
