### PR TITLE
Fix error messages of some assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix invalid arguments logging in some of assertions.
+
 ## 0.5.6
 
 - Add `xfail` status.

--- a/luatest/assertions.lua
+++ b/luatest/assertions.lua
@@ -186,10 +186,12 @@ end
 -- @number actual
 -- @number expected
 -- @number margin
-function M.almost_equals(actual, expected, margin)
+-- @string[opt] message
+function M.almost_equals(actual, expected, margin, message)
     if not tonumber(actual) or not tonumber(expected) or not tonumber(margin) then
-        fail_fmt(2, 'almost_equals: must supply only number arguments.\nArguments supplied: %s, %s, %s',
-            prettystr(actual), prettystr(expected), prettystr(margin))
+        fail_fmt(2, message, 'almost_equals: must supply only number arguments.\n' ..
+            'Arguments supplied: %s, %s, %s',
+            actual, expected, margin)
     end
     if margin < 0 then
         failure('almost_equals: margin must not be negative, current value is ' .. margin, 2)
@@ -221,7 +223,7 @@ end
 function M.assert_lt(left, right, message)
     if not tonumber(left) or not tonumber(right) then
         print(prettystr(right))
-        fail_fmt(2, 'assert_lt: must supply only number arguments.\nArguments supplied: %s, %s',
+        fail_fmt(2, message, 'assert_lt: must supply only number arguments.\nArguments supplied: %s, %s',
             prettystr(left), prettystr(right))
     end
     if not comparator.lt(tonumber(left), tonumber(right)) then
@@ -236,7 +238,7 @@ end
 -- @string[opt] message
 function M.assert_gt(left, right, message)
     if not tonumber(left) or not tonumber(right) then
-        fail_fmt(2, 'assert_gt: must supply only number arguments.\nArguments supplied: %s, %s',
+        fail_fmt(2, message, 'assert_gt: must supply only number arguments.\nArguments supplied: %s, %s',
             prettystr(left), prettystr(right))
     end
     if not comparator.lt(tonumber(right), tonumber(left)) then
@@ -251,7 +253,7 @@ end
 -- @string[opt] message
 function M.assert_le(left, right, message)
     if not tonumber(left) or not tonumber(right) then
-        fail_fmt(2, 'assert_le: must supply only number arguments.\nArguments supplied: %s, %s',
+        fail_fmt(2, message, 'assert_le: must supply only number arguments.\nArguments supplied: %s, %s',
             prettystr(left), prettystr(right))
     end
     if not (comparator.le(tonumber(left), tonumber(right))) then
@@ -266,7 +268,7 @@ end
 -- @string[opt] message
 function M.assert_ge(left, right, message)
     if not tonumber(left) or not tonumber(right) then
-        fail_fmt(2, 'assert_ge: must supply only number arguments.\nArguments supplied: %s, %s',
+        fail_fmt(2, message, 'assert_ge: must supply only number arguments.\nArguments supplied: %s, %s',
             prettystr(left), prettystr(right))
     end
     if not (comparator.le(tonumber(right), tonumber(left))) then

--- a/test/assertions_test.lua
+++ b/test/assertions_test.lua
@@ -37,10 +37,11 @@ g.test_assert_almost_equals_for_cdata = function()
 
     helper.assert_failure_contains('Values are not almost equal', t.assert_almost_equals, 1, 3ULL, 1)
     helper.assert_failure_contains('Values are not almost equal', t.assert_almost_equals, 1LL, 3, 1)
-    helper.assert_failure_contains('must supply only number arguments', t.assert_almost_equals, box.NULL, 3, 1)
+    helper.assert_failure_contains('must supply only number arguments.\n'..
+        'Arguments supplied: cdata<void *>: NULL, 3, 1', t.assert_almost_equals, box.NULL, 3, 1)
 
     t.assert_not_almost_equals(1, 3ULL, 1)
-    t.assert_not_almost_equals(1LL, 3, 1)
+    t.assert_not_almost_equals(1LL, 3, 1LL)
 end
 
 g.test_assert_with_extra_message_not_string = function()
@@ -49,4 +50,15 @@ g.test_assert_with_extra_message_not_string = function()
     helper.assert_failure_equals(raw_msg, t.assert, nil, nil)
     helper.assert_failure_equals(raw_msg, t.assert, nil, box.NULL)
     helper.assert_failure_equals('321\n' .. raw_msg, t.assert, nil, 321)
+end
+
+g.test_assert_comparisons_error = function()
+    helper.assert_failure_contains('must supply only number arguments.\n'..
+    'Arguments supplied: \"one\", 3', t.assert_le, 'one', 3)
+    helper.assert_failure_contains('must supply only number arguments.\n'..
+    'Arguments supplied: \"one\", 3', t.assert_lt, 'one', 3)
+    helper.assert_failure_contains('must supply only number arguments.\n'..
+    'Arguments supplied: \"one\", 3', t.assert_ge, 'one', 3)
+    helper.assert_failure_contains('must supply only number arguments.\n'..
+    'Arguments supplied: \"one\", 3', t.assert_gt, 'one', 3)
 end


### PR DESCRIPTION
In case of invalid argument some of assertions returned corrupted error message. It has been fixed. Moreover, `test_assert_almost_equals_for_cdata` was flaky and the problem seemed to be in luajit's `tonumber`, which rarely returned `nil` on `1LL`. The test is rearranged. 

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #183
