### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/luatest-scm-1.rockspec
+++ b/luatest-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = 'luatest'
 version = 'scm-1'
 source = {
-    url = 'git://github.com/tarantool/luatest.git',
+    url = 'git+https://github.com/tarantool/luatest.git',
     branch = 'master',
 }
 description = {


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587