### PR TITLE
Fix confusing err message from `assert_not_equals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Fix invalid arguments logging in some of assertions.
+- Fix invalid arguments logging in some assertions.
+- Fix confusing error message from `assert_not_equals` function.
 
 ## 0.5.6
 

--- a/luatest/assertions.lua
+++ b/luatest/assertions.lua
@@ -284,7 +284,7 @@ end
 -- @string[opt] message
 function M.assert_not_equals(actual, expected, message)
     if comparator.equals(actual, expected) then
-        fail_fmt(2, message, 'Received unexpected value: %s', prettystr(actual))
+        fail_fmt(2, message, 'Actual and expected values are equal: %s', prettystr(actual))
     end
 end
 

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -28,7 +28,7 @@ g.test_assert_equals_box_null = function()
     helper.assert_failure(t.assert_equals, {1, nil, 3}, {1, 3})
 
     t.assert_not_equals(box.NULL, 1ULL)
-    helper.assert_failure_contains('Received unexpected value', t.assert_not_equals, box.NULL, nil)
+    helper.assert_failure_contains('Actual and expected values are equal', t.assert_not_equals, box.NULL, nil)
 end
 
 g.test_assert_is_box_null = function()

--- a/test/luaunit/error_msg_test.lua
+++ b/test/luaunit/error_msg_test.lua
@@ -34,10 +34,10 @@ function g.test_assert_not_almost_equalsMsg()
 end
 
 function g.test_assert_not_equalsMsg()
-    assert_failure_equals('Received unexpected value: 1', t.assert_not_equals, 1, 1 )
-    assert_failure_matches('Received unexpected value: {1, 2}', t.assert_not_equals, {1,2}, {1,2})
-    assert_failure_equals('Received unexpected value: nil', t.assert_not_equals, nil, nil)
-    assert_failure_equals('toto\nReceived unexpected value: 1', t.assert_not_equals, 1, 1, 'toto' )
+    assert_failure_equals('Actual and expected values are equal: 1', t.assert_not_equals, 1, 1)
+    assert_failure_matches('Actual and expected values are equal: {1, 2}', t.assert_not_equals, {1,2}, {1,2})
+    assert_failure_equals('Actual and expected values are equal: nil', t.assert_not_equals, nil, nil)
+    assert_failure_equals('toto\nActual and expected values are equal: 1', t.assert_not_equals, 1, 1, 'toto')
 end
 
 function g.test_assert_not()
@@ -326,10 +326,10 @@ local pp = require('luatest.pp')
 
 function g.test_printTableWithRef()
     pp.TABLE_REF_IN_ERROR_MSG = true
-    assert_failure_matches('Received unexpected value: <table: 0?x?[%x]+> {1, 2}',
+    assert_failure_matches('Actual and expected values are equal: <table: 0?x?[%x]+> {1, 2}',
         t.assert_not_equals, {1,2}, {1,2})
     -- trigger multiline prettystr
-    assert_failure_matches('Received unexpected value: <table: 0?x?[%x]+> {1, 2, 3, 4}',
+    assert_failure_matches('Actual and expected values are equal: <table: 0?x?[%x]+> {1, 2, 3, 4}',
         t.assert_not_equals, {1,2,3,4}, {1,2,3,4})
     assert_failure_matches('expected: false or nil, actual: <table: 0?x?[%x]+> {}', t.assert_not, {})
     local v = {1,2}


### PR DESCRIPTION
The `assert_not_equals` function printed the following error message
when the values were equal:

    Received unexpected value: <value>

This message sounds quite confusing because in this case the question
is raised: 'what is the expected value?'. But the expected value is any
value different from `<value>`. So the error message was changed to

    Actual and expected values are equal: <value>

which is more comprehensible.

Closes #206