### PR TITLE
Fix confusing doc strings and err messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix invalid arguments logging in some assertions.
 - Fix confusing error message from `assert_not_equals` function.
+- Fix confusing error message from `assert_items_equals` function.
+- Fix confusing error message from `assert_items_include` function.
 
 ## 0.5.6
 

--- a/README.rst
+++ b/README.rst
@@ -175,15 +175,15 @@ List of luatest functions
 +--------------------------------------------------------------------+-----------------------------------------------+
 | ``assert_eval_to_true (value[, message])``                         | Alias for assert.                             |
 +--------------------------------------------------------------------+-----------------------------------------------+
-| ``assert_items_include (actual, expected[, message])``             | Checks that actual includes all items of      |
-|                                                                    | expected.                                     |
+| ``assert_items_include (actual, expected[, message])``             | Checks that one table includes all items of   |
+|                                                                    | another, irrespective of their keys.          |
 +--------------------------------------------------------------------+-----------------------------------------------+
 | ``assert_is (actual, expected[, message])``                        | Check that values are the same.               |
 +--------------------------------------------------------------------+-----------------------------------------------+
 | ``assert_is_not (actual, expected[, message])``                    | Check that values are not the same.           |
 +--------------------------------------------------------------------+-----------------------------------------------+
-| ``assert_items_equals (actual, expected[, message])``              | Checks equality of tables regardless of the   |
-|                                                                    | order of elements.                            |
+| ``assert_items_equals (actual, expected[, message])``              | Checks that two tables contain the same items,|
+|                                                                    | irrespective of their keys.                   |
 +--------------------------------------------------------------------+-----------------------------------------------+
 | ``assert_nan (value[, message])``                                  |                                               |
 +--------------------------------------------------------------------+-----------------------------------------------+

--- a/luatest/assertions.lua
+++ b/luatest/assertions.lua
@@ -194,7 +194,7 @@ function M.almost_equals(actual, expected, margin, message)
             actual, expected, margin)
     end
     if margin < 0 then
-        failure('almost_equals: margin must not be negative, current value is ' .. margin, 2)
+        failure('almost_equals: margin must not be negative, current value is ' .. margin, nil, 2)
     end
     return math.abs(tonumber(expected - actual)) <= margin
 end
@@ -304,7 +304,7 @@ function M.assert_not_almost_equals(actual, expected, margin, message)
     end
 end
 
---- Checks equality of tables regardless of the order of elements.
+--- Checks that two tables contain the same items, irrespective of their keys.
 --
 -- @param actual
 -- @param expected
@@ -312,12 +312,12 @@ end
 function M.assert_items_equals(actual, expected, message)
     if comparator.is_subset(actual, expected) ~= 0 then
         expected, actual = prettystr_pairs(expected, actual)
-        fail_fmt(2, message, 'Content of the tables are not identical:\nExpected: %s\nActual: %s',
+        fail_fmt(2, message, 'Item values of the tables are not identical\nExpected table: %s\nActual table: %s',
                  expected, actual)
     end
 end
 
---- Checks that actual includes all items of expected.
+--- Checks that one table includes all items of another, irrespective of their keys.
 --
 -- @param actual
 -- @param expected
@@ -325,13 +325,13 @@ end
 function M.assert_items_include(actual, expected, message)
     if not comparator.is_subset(expected, actual) then
         expected, actual = prettystr_pairs(expected, actual)
-        fail_fmt(2, message, 'Expected all elements from: %s\nTo be present in: %s', expected, actual)
+        fail_fmt(2, message, 'Expected all item values from: %s\nTo be present in: %s', expected, actual)
     end
 end
 
 local function table_covers(actual, expected)
     if type(actual) ~= 'table' or type(expected) ~= 'table' then
-        failure('Argument 1 and 2 must be tables', 3)
+        failure('Argument 1 and 2 must be tables', nil, 3)
     end
     local sliced = {}
     for k, _ in pairs(expected) do

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -58,7 +58,7 @@ end
 
 g.test_assert_items_equals_tnt_tuples = function()
     t.assert_items_equals({box.tuple.new(1)}, {box.tuple.new(1)})
-    helper.assert_failure_contains('Content of the tables are not identical',
+    helper.assert_failure_contains('Item values of the tables are not identical',
         t.assert_items_equals, {box.tuple.new(1)}, {box.tuple.new(2)})
 end
 

--- a/test/luaunit/error_msg_test.lua
+++ b/test/luaunit/error_msg_test.lua
@@ -257,16 +257,17 @@ function g.test_assert_is_not()
 end
 
 function g.test_assert_items_equals()
-    assert_failure_matches('Content of the tables are not identical:\nExpected: {one = 2, two = 3}\nActual: {1, 2}',
-        t.assert_items_equals, {1,2}, {one=2, two=3})
+    assert_failure_matches([[Item values of the tables are not identical
+Expected table: {one = 2, two = 3}
+Actual table: {1, 2}]], t.assert_items_equals, {1,2}, {one=2, two=3})
     -- actual table empty, = doesn't contain expected value
-    assert_failure_contains('Content of the tables are not identical' , t.assert_items_equals, {}, {1})
+    assert_failure_contains('Item values of the tables are not identical' , t.assert_items_equals, {}, {1})
     -- type mismatch
-    assert_failure_contains('Content of the tables are not identical' , t.assert_items_equals, nil, 'foobar')
+    assert_failure_contains('Item values of the tables are not identical' , t.assert_items_equals, nil, 'foobar')
     -- value mismatch
-    assert_failure_contains('Content of the tables are not identical' , t.assert_items_equals, 'foo', 'bar')
+    assert_failure_contains('Item values of the tables are not identical' , t.assert_items_equals, 'foo', 'bar')
     -- value mismatch
-    assert_failure_contains('toto\nContent of the tables are not identical',
+    assert_failure_contains('toto\nItem values of the tables are not identical',
         t.assert_items_equals, 'foo', 'bar', 'toto')
 end
 
@@ -335,9 +336,9 @@ function g.test_printTableWithRef()
     local v = {1,2}
     assert_failure_matches('expected and actual object should be different: <table: 0?x?[%x]+> {1, 2}',
         t.assert_is_not, v, v)
-    assert_failure_matches([[Content of the tables are not identical:
-Expected: <table: 0?x?[%x]+> {one = 2, two = 3}
-Actual: <table: 0?x?[%x]+> {1, 2}]], t.assert_items_equals, {1,2}, {one=2, two=3})
+    assert_failure_matches([[Item values of the tables are not identical
+Expected table: <table: 0?x?[%x]+> {one = 2, two = 3}
+Actual table: <table: 0?x?[%x]+> {1, 2}]], t.assert_items_equals, {1,2}, {one=2, two=3})
     assert_failure_matches([[expected: <table: 0?x?[%x]+> {1, 2}
 actual: <table: 0?x?[%x]+> {2, 1}]], t.assert_equals, {2,1}, {1,2})
     -- trigger multiline prettystr


### PR DESCRIPTION
This patch fixes confusing docstrings for `assert_items_equals` and
`assert_items_include` functions and error messages that the functions
produce when asserting fails.

These functions do a comparison of actual and expected tables only by
field values (keys are not considered) but docstrings and error messages
made people think that field keys are considered as well which is wrong.

Closes #117
