### PR TITLE
Print message instead of `nil` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix confusing error message from `assert_not_equals` function.
 - Fix confusing error message from `assert_items_equals` function.
 - Fix confusing error message from `assert_items_include` function.
+- Print `(no reason specified)` message instead of `nil` value when the test is 
+  skipped and no reason is specified.
 
 ## 0.5.6
 

--- a/luatest/assertions.lua
+++ b/luatest/assertions.lua
@@ -118,7 +118,7 @@ end
 --
 -- @string message
 function M.skip(message)
-    utils.luatest_error('skip', message, 2)
+    utils.luatest_error('skip', message or '(no reason specified)', 2)
 end
 
 --- Skip a running test if condition is met.
@@ -127,14 +127,14 @@ end
 -- @string message
 function M.skip_if(condition, message)
     if condition and condition ~= nil then
-        utils.luatest_error('skip', message, 2)
+        utils.luatest_error('skip', message or '(no reason specified)', 2)
     end
 end
 
 function M.run_only_if(condition, message)
     -- continue a running test if condition is met, else skip it
     if not (condition and condition ~= nil) then
-        utils.luatest_error('skip', prettystr(message), 2)
+        utils.luatest_error('skip', message or '(no reason specified)', 2)
     end
 end
 

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -79,6 +79,24 @@ g.test_skip_if_tnt_specific = function()
     t.assert_equals(helper.assert_failure(t.skip_if, {}, 'expected').status, 'skip')
 end
 
+g.test_skip_no_reason_specified = function()
+    local result = helper.assert_failure(t.skip)
+    t.assert_equals(result.status, 'skip')
+    t.assert_equals(result.message, '(no reason specified)')
+end
+
+g.test_skip_if_no_reason_specified = function()
+    local result = helper.assert_failure(t.skip_if, true)
+    t.assert_equals(result.status, 'skip')
+    t.assert_equals(result.message, '(no reason specified)')
+end
+
+g.test_run_only_if_no_reason_specified = function()
+    local result = helper.assert_failure(t.run_only_if, false)
+    t.assert_equals(result.status, 'skip')
+    t.assert_equals(result.message, '(no reason specified)')
+end
+
 g.test_success_if_tnt_specific = function()
     assert_any_error(t.success_if, box.NULL)
     t.assert_equals(helper.assert_failure(t.success_if, true).status, 'success')


### PR DESCRIPTION
When a test case contained the skip/skip_if/run_only_if function without
an optional message, luatest printed `nil` after the test status.

Now luatest prints the `(no reason specified)` message.

Closes #171 