### PR TITLE
Raise error if net_box_uri > max unix socket path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix confusing error message from `assert_items_include` function.
 - Print `(no reason specified)` message instead of `nil` value when the test is 
   skipped and no reason is specified.
+- Check `net_box_uri` param is less than max Unix domain socket path length.
 
 ## 0.5.6
 


### PR DESCRIPTION
Since luatest supports in luatest/server.lua the socket connection to
tarantool instances via the net_box_uri param, we need to check that
the socket's path length is less than the max length of the Unix domain
socket path allowed by a system. 
Otherwise, we will get the `No buffer space available` error which is not 
clear for users and may take some time to understand what's wrong.

Closes #152 
