### PR TITLE
Make test run summary report consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Print `(no reason specified)` message instead of `nil` value when the test is 
   skipped and no reason is specified.
 - Check `net_box_uri` param is less than max Unix domain socket path length.
+- Change test run summary report: use verbs in past simple tense (succeeded, 
+  failed, xfailed, etc.) instead of nouns (success(es), fail(s), xfail(s), etc.)
 
 ## 0.5.6
 

--- a/luatest/output/generic.lua
+++ b/luatest/output/generic.lua
@@ -49,43 +49,34 @@ function Output.mt:end_suite()
 end
 -- luacheck: pop
 
-local function conditional_plural(number, singular)
-    -- returns a grammatically well-formed string "%d <singular/plural>"
-    local suffix = ''
-    if number ~= 1 then -- use plural
-        suffix = (singular:sub(-2) == 'ss') and 'es' or 's'
-    end
-    return string.format('%d %s%s', number, singular, suffix)
-end
-
 function Output.mt:status_line(colors)
     colors = colors or {success = '', failure = '', reset = '', xfail = ''}
     -- return status line string according to results
     local tests = self.result.tests
     local s = {
         string.format('Ran %d tests in %0.3f seconds', #tests.all - #tests.skip, self.result.duration),
-        colors.success .. conditional_plural(#tests.success, 'success') .. colors.reset,
+        string.format("%s%d %s%s", colors.success, #tests.success, 'succeeded', colors.reset),
     }
     if #tests.xfail > 0 then
-        table.insert(s, colors.xfail .. conditional_plural(#tests.xfail, 'xfail') .. colors.reset)
+        table.insert(s, string.format("%s%d %s%s", colors.xfail, #tests.xfail, 'xfailed', colors.reset))
     end
     if #tests.xsuccess > 0 then
-        table.insert(s, colors.failure .. conditional_plural(#tests.xsuccess, 'xsuccess') .. colors.reset)
+        table.insert(s, string.format("%s%d %s%s", colors.failure, #tests.xsuccess, 'xsucceeded', colors.reset))
     end
     if #tests.fail > 0 then
-        table.insert(s, colors.failure .. conditional_plural(#tests.fail, 'fail') .. colors.reset)
+        table.insert(s, string.format("%s%d %s%s", colors.failure, #tests.fail, 'failed', colors.reset))
     end
     if #tests.error > 0 then
-        table.insert(s, colors.failure .. conditional_plural(#tests.error, 'error') .. colors.reset)
+        table.insert(s, string.format("%s%d %s%s", colors.failure, #tests.error, 'errored', colors.reset))
     end
     if #tests.fail == 0 and #tests.error == 0 and #tests.xsuccess == 0 then
-        table.insert(s, '0 failures')
+        table.insert(s, '0 failed')
     end
     if #tests.skip > 0 then
         table.insert(s, string.format("%d skipped", #tests.skip))
     end
     if self.result.not_selected_count > 0 then
-        table.insert(s, string.format("%d not-selected", self.result.not_selected_count))
+        table.insert(s, string.format("%d not selected", self.result.not_selected_count))
     end
     return table.concat(s, ', ')
 end


### PR DESCRIPTION
Until this moment luatest printed different test run summary reports
depending on how many tests succeeded, failed, xfailed, etc. It used
the plural form for test status nouns (success, fail, xfail, etc.)
if there were 0 or > 1 affected tests and the single form if it was 1
test.

It was decided to fix this inconsistency and use verbs in past simple
tense (succeeded, failed, xfailed, etc.) for all cases.

Closes #172