### PR TITLE
Add new module tarantool.lua

### DIFF
--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -5,6 +5,11 @@ local luatest = setmetatable({}, {__index = require('luatest.assertions')})
 luatest.Process = require('luatest.process')
 luatest.VERSION = require('luatest.VERSION')
 
+--- Tarantool related functions.
+--
+-- @see luatest.tarantool
+luatest.tarantool = require('luatest.tarantool')
+
 --- Helpers.
 --
 -- @see luatest.helpers

--- a/luatest/tarantool.lua
+++ b/luatest/tarantool.lua
@@ -1,0 +1,39 @@
+--- Collection of Tarantool related functions.
+--
+-- @module luatest.tarantool
+
+local tarantool = require('tarantool')
+
+local assertions = require('luatest.assertions')
+
+local M = {}
+
+--- Return true if Tarantool build type is Debug.
+function M.is_debug_build()
+    return tarantool.build.target:endswith('-Debug')
+end
+
+--- Return true if Tarantool package is Enterprise.
+function M.is_enterprise_package()
+    return tarantool.package == 'Tarantool Enterprise'
+end
+
+--- Skip a running test unless Tarantool build type is Debug.
+--
+-- @string[opt] message
+function M.skip_if_not_debug(message)
+    assertions.skip_if(
+        not M.is_debug_build(), message or 'build type is not Debug'
+    )
+end
+
+--- Skip a running test if Tarantool package is Enterprise.
+--
+-- @string[opt] message
+function M.skip_if_enterprise(message)
+    assertions.skip_if(
+        M.is_enterprise_package(), message or 'package is Enterprise'
+    )
+end
+
+return M


### PR DESCRIPTION
This patch adds a new module tarantool.lua to the repo that is a copy of
the test/luatest_helpers/misc.lua module [1] in the tarantool/tarantool
repo. The later should be deleted in the nearest future.

[1] https://github.com/tarantool/tarantool/blob/5c62f01bb6d7a88855108925b8ed0ba3ca344d2b/test/luatest_helpers/misc.lua

Part of #238