### PR TITLE
Add new func `find_fiber_by_name` to tarantool.lua

### DIFF
--- a/luatest/tarantool.lua
+++ b/luatest/tarantool.lua
@@ -2,6 +2,7 @@
 --
 -- @module luatest.tarantool
 
+local fiber = require('fiber')
 local tarantool = require('tarantool')
 
 local assertions = require('luatest.assertions')
@@ -34,6 +35,18 @@ function M.skip_if_enterprise(message)
     assertions.skip_if(
         M.is_enterprise_package(), message or 'package is Enterprise'
     )
+end
+
+--- Search for a fiber with the specified name and return the fiber object.
+--
+-- @string name
+function M.find_fiber_by_name(name)
+    for id, f in pairs(fiber.info()) do
+        if f.name == name then
+            return fiber.find(id)
+        end
+    end
+    return nil
 end
 
 return M


### PR DESCRIPTION
This patch adds a new function to the tarantool.lua module that is a
copy of the function in the test/luatest_helpers/fiber.lua module [1]
in the tarantool/tarantool repo. The fiber.lua should be deleted in
the nearest future.

[1] https://github.com/tarantool/tarantool/blob/256da01046da8f4fbe81d629cf54ae32dc04a1fb/test/luatest_helpers/fiber.lua