### PR TITLE
Add new module replica_proxy.lua

### DIFF
--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -10,7 +10,7 @@ luatest.VERSION = require('luatest.VERSION')
 -- @see luatest.replica_proxy
 luatest.replica_proxy = require('luatest.replica_proxy')
 
---- Tarantool related functions.
+--- Module with collection of test helpers related to Tarantool instance.
 --
 -- @see luatest.tarantool
 luatest.tarantool = require('luatest.tarantool')

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -5,6 +5,11 @@ local luatest = setmetatable({}, {__index = require('luatest.assertions')})
 luatest.Process = require('luatest.process')
 luatest.VERSION = require('luatest.VERSION')
 
+--- Module to manage connection to Tarantool replication instances via proxy.
+--
+-- @see luatest.replica_proxy
+luatest.replica_proxy = require('luatest.replica_proxy')
+
 --- Tarantool related functions.
 --
 -- @see luatest.tarantool

--- a/luatest/replica_conn.lua
+++ b/luatest/replica_conn.lua
@@ -1,0 +1,145 @@
+local checks = require('checks')
+local fiber = require('fiber')
+local socket = require('socket')
+
+local TIMEOUT = 0.001
+
+local Connection = {
+    constructor_checks = {
+        client_socket = '?table',
+        server_socket_path = 'string',
+        process_client = '?table',
+        process_server = '?table',
+    },
+}
+
+function Connection:inherit(object)
+    setmetatable(object, self)
+    self.__index = self
+    return object
+end
+
+function Connection:new(object)
+    checks('table', self.constructor_checks)
+    self:inherit(object)
+    object:initialize()
+    return object
+end
+
+function Connection:initialize()
+    self.running = false
+    self.client_connected = true
+    self.server_connected = false
+    self.client_fiber = nil
+    self.server_fiber = nil
+
+    if self.process_client == nil then
+        self.process_client = {
+            pre = nil,
+            func = self.forward_to_server,
+            post = self.close_client_socket,
+        }
+    end
+
+    if self.process_server == nil then
+        self.process_server = {
+            pre = nil,
+            func = self.forward_to_client,
+            post = self.close_server_socket,
+        }
+    end
+
+    self:connect_server_socket()
+end
+
+function Connection:connect_server_socket()
+    self.server_socket = socket('PF_UNIX', 'SOCK_STREAM', 0)
+    if self.server_socket:sysconnect('unix/', self.server_socket_path) == false
+    then
+        self.server_socket:close()
+        self.server_socket = nil
+        return
+    end
+    self.server_socket:nonblock(true)
+    self.server_connected = true
+
+    self.server_fiber = self:process_socket(self.server_socket,
+        self.process_server)
+end
+
+function Connection:process_socket(sock, process)
+    local f = fiber.new(function()
+        if process.pre ~= nil then process.pre(self) end
+
+        while sock:peer() do
+            if not self.running then
+                fiber.sleep(TIMEOUT)
+            elseif sock:readable(TIMEOUT) then
+                local request = sock:recv()
+                if request == nil or #request == 0 then break end
+                if process.func ~= nil then process.func(self, request) end
+            end
+        end
+
+        if process.post ~= nil then process.post(self) end
+    end)
+    f:set_joinable(true)
+    f:name('ProxyConnectionIO')
+    return f
+end
+
+function Connection:start()
+    self.running = true
+    if self.client_fiber == nil or self.client_fiber:status() == 'dead' then
+        self.client_fiber = self:process_socket(self.client_socket,
+            self.process_client)
+    end
+end
+
+function Connection:pause()
+    self.running = false
+end
+
+function Connection:resume()
+    self.running = true
+end
+
+function Connection:stop()
+    self:close_client_socket()
+    self:close_server_socket()
+end
+
+function Connection:forward_to_server(data)
+    if not self.server_connected then
+        self:connect_server_socket()
+    end
+    if self.server_connected and self.server_socket:writable() then
+        self.server_socket:write(data)
+    end
+end
+
+function Connection:forward_to_client(data)
+    if self.client_connected and self.client_socket:writable() then
+        self.client_socket:write(data)
+    end
+end
+
+function Connection:close_server_socket()
+    if self.server_connected then
+        self.server_socket:shutdown(socket.SHUT_RW)
+        self.server_socket:close()
+        self.server_connected = false
+        self.server_fiber:join()
+    end
+end
+
+function Connection:close_client_socket()
+    if self.client_connected then
+        self.client_socket:shutdown(socket.SHUT_RW)
+        self.client_socket:close()
+        self.client_connected = false
+        self.client_fiber:join()
+    end
+end
+
+return Connection

--- a/luatest/replica_proxy.lua
+++ b/luatest/replica_proxy.lua
@@ -1,0 +1,139 @@
+--- Manage connection to Tarantool replication instances via proxy.
+--
+-- @module luatest.replica_proxy
+
+local checks = require('checks')
+local fiber = require('fiber')
+local log = require('log')
+local socket = require('socket')
+
+local Connection = require('luatest.replica_conn')
+
+local TIMEOUT = 0.001
+local BACKLOG = 512
+
+local Proxy = {
+    constructor_checks = {
+        client_socket_path = 'string',
+        server_socket_path = 'string',
+        process_client = '?table',
+        process_server = '?table',
+    },
+}
+
+function Proxy:inherit(object)
+    setmetatable(object, self)
+    self.__index = self
+    return object
+end
+
+--- Build a proxy object.
+--
+-- @param object
+-- @string object.client_socket_path Path to a UNIX socket where proxy will await new connections.
+-- @string object.server_socket_path Path to a UNIX socket where Tarantool server is listening to.
+-- @tab[opt] object.process_client Table describing how to process the client socket.
+-- @tab[opt] object.process_server Table describing how to process the server socket.
+-- @return Input object.
+function Proxy:new(object)
+    checks('table', self.constructor_checks)
+    self:inherit(object)
+    object:initialize()
+    return object
+end
+
+function Proxy:initialize()
+    self.connections = {}
+    self.accept_new_connections = true
+    self.running = false
+
+    self.client_socket = socket('PF_UNIX', 'SOCK_STREAM', 0)
+end
+
+--- Stop accepting new connections on the client socket.
+-- Join the fiber created by proxy:start() and close the client socket.
+-- Also, stop all active connections.
+function Proxy:stop()
+    self.running = false
+    self.worker:join()
+    for _, c in pairs(self.connections) do
+        c:stop()
+    end
+end
+
+--- Pause accepting new connections and pause all active connections.
+function Proxy:pause()
+    self.accept_new_connections = false
+    for _, c in pairs(self.connections) do
+        c:pause()
+    end
+end
+
+--- Resume accepting new connections and resume all paused connections.
+function Proxy:resume()
+    for _, c in pairs(self.connections) do
+        c:resume()
+    end
+    self.accept_new_connections = true
+end
+
+--- Start accepting new connections on the client socket in a new fiber.
+--
+-- @tab[opt] opts
+-- @bool[opt] opts.force Remove the client socket before start.
+function Proxy:start(opts)
+    checks('table', {force = '?boolean'})
+    if opts ~= nil and opts.force then
+        os.remove(self.client_socket_path)
+    end
+
+    if not self.client_socket:bind('unix/', self.client_socket_path) then
+        log.error("Failed to bind client socket: %s", self.client_socket:error())
+        return false
+    end
+
+    self.client_socket:nonblock(true)
+    if not self.client_socket:listen(BACKLOG) then
+        log.error("Failed to listen on client socket: %s",
+            self.client_socket:error())
+        return false
+    end
+
+    self.running = true
+    self.worker = fiber.new(function()
+        while self.running do
+            if not self.accept_new_connections then
+                fiber.sleep(TIMEOUT)
+                goto continue
+            end
+
+            if not self.client_socket:readable(TIMEOUT) then
+                goto continue
+            end
+
+            local client = self.client_socket:accept()
+            if client == nil then goto continue end
+            client:nonblock(true)
+
+            local conn = Connection:new({
+                client_socket = client,
+                server_socket_path = self.server_socket_path,
+                process_client = self.process_client,
+                process_server = self.process_server,
+            })
+            table.insert(self.connections, conn)
+            conn:start()
+            :: continue ::
+        end
+
+        self.client_socket:shutdown(socket.SHUT_RW)
+        self.client_socket:close()
+        os.remove(self.client_socket_path)
+    end)
+    self.worker:set_joinable(true)
+    self.worker:name('ProxyWorker')
+
+    return true
+end
+
+return Proxy

--- a/luatest/tarantool.lua
+++ b/luatest/tarantool.lua
@@ -1,4 +1,4 @@
---- Collection of Tarantool related functions.
+--- Collection of test helpers related to Tarantool instance.
 --
 -- @module luatest.tarantool
 
@@ -21,7 +21,7 @@ end
 
 --- Skip a running test unless Tarantool build type is Debug.
 --
--- @string[opt] message
+-- @string[opt] message Message to describe the reason.
 function M.skip_if_not_debug(message)
     assertions.skip_if(
         not M.is_debug_build(), message or 'build type is not Debug'
@@ -30,7 +30,7 @@ end
 
 --- Skip a running test if Tarantool package is Enterprise.
 --
--- @string[opt] message
+-- @string[opt] message Message to describe the reason.
 function M.skip_if_enterprise(message)
     assertions.skip_if(
         M.is_enterprise_package(), message or 'package is Enterprise'
@@ -39,7 +39,7 @@ end
 
 --- Search for a fiber with the specified name and return the fiber object.
 --
--- @string name
+-- @string name Fiber name.
 function M.find_fiber_by_name(name)
     for id, f in pairs(fiber.info()) do
         if f.name == name then


### PR DESCRIPTION
This patch adds a new module replica_proxy.lua to the repo that is
a copy of the test/luatest_helpers/proxy/proxy.lua module [1] in the
tarantool/tarantool repo. The later should be deleted in the nearest
future.

The new module is intended to manage connection to Tarantool replication
instances via proxy.

Also, the replica_conn.lua module is added that is considered as an
internal one and not exposed to public API.

[1] https://github.com/tarantool/tarantool/blob/ad420846861a117b2b7e82b434acd1372c6abe08/test/luatest_helpers/proxy/proxy.lua

Part of https://github.com/tarantool/luatest/issues/251