### PR TITLE
Remove link to travis-ci from the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Overview
 -------------------------------
 
-Tool for testing tarantool applications. (`Build Status <https://travis-ci.com/tarantool/luatest.svg?branch=master)](https://travis-ci.com/tarantool/luatest>`_).
+Tool for testing tarantool applications.
 
 Highlights:
 


### PR DESCRIPTION
Removed a link to Travis CI which we don't use anymore.