### PR TITLE
Print Tarantool version used by luatest 

### DIFF
--- a/bin/luatest
+++ b/bin/luatest
@@ -1,3 +1,5 @@
 #!/usr/bin/env tarantool
 
+print(('Tarantool version is %s'):format(require('tarantool').version))
+
 require('luatest.cli_entrypoint')()


### PR DESCRIPTION
Printing out tarantool version at bin/luatest.

Added method to printing out used tarantool version.

Resolves #240
