### PR TITLE
Change `coverage_report` parameter type to boolean

### DIFF
--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -32,7 +32,7 @@ local Server = {
 
         alias = '?string',
 
-        coverage_report = '?string',
+        coverage_report = '?boolean',
     },
 }
 
@@ -157,7 +157,7 @@ function Server:restart(params)
 
         alias = '?string',
 
-        coverage_report = '?string',
+        coverage_report = '?boolean',
     })
     if not self.process then
         log.warn("Process wasn't started")


### PR DESCRIPTION
It looks like the parameter was marked as a string one by a copy-paste mistake. Looking through the source code, it is clear that it should have the boolean type.

Fixes #119
