### PR TITLE
Make server_instance.lua work for Tarantool < 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Make the internal server_instance.lua script compatible with Tarantool 
+  versions < 2.8.0-139-g357f15517.
 - Extend `server.lua` API:
   * Update parameters of the `Server:new()` function:
     - The `alias` parameter defaults to 'server'.

--- a/luatest/server_instance.lua
+++ b/luatest/server_instance.lua
@@ -35,7 +35,9 @@ end
 -- requests. With the default timeout of 3 seconds, such tests would still pass,
 -- but slow down the overall test run, because the server would take longer to
 -- stop. Setting the timeout to infinity makes such bad tests hang and fail.
-box.ctl.set_on_shutdown_timeout(TIMEOUT_INFINITY)
+if type(box.ctl.set_on_shutdown_timeout) == 'function' then
+    box.ctl.set_on_shutdown_timeout(TIMEOUT_INFINITY)
+end
 
 local run_before_box_cfg = os.getenv('TARANTOOL_RUN_BEFORE_BOX_CFG')
 if run_before_box_cfg then


### PR DESCRIPTION
The `box.ctl.set_on_shutdown_timeout()` function is available only since Tarantool 2.8.0-139-g357f15517. This patch makes the server_instance.lua script compatible with older Tarantool versions.