### PR TITLE
Fix instance file permissions when installing luatest as rock

### DIFF
--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -232,13 +232,21 @@ function Server:start(opts)
         table.insert(log_cmd, string.format('%s=%q', k, v))
         env[k] = v
     end
+    table.insert(log_cmd, arg[-1])
     table.insert(log_cmd, self.command)
     for _, v in ipairs(self.args) do
         table.insert(log_cmd, string.format('%q', v))
     end
     log.debug(table.concat(log_cmd, ' '))
 
-    self.process = Process:start(self.command, self.args, env, {
+    -- When luatest is installed as a rock, server_instance.lua script won't
+    -- have execution permissions even though it has them in the source tree,
+    -- and won't be able to be run while a server start.
+    -- To bypass this issue, we start a server process as `tarantool <script>`
+    -- instead of just `<script>`.
+    local args = table.copy(self.args)
+    table.insert(args, 1, self.command)
+    self.process = Process:start(arg[-1], args, env, {
         chdir = self.chdir,
         output_prefix = self.alias,
     })

--- a/luatest/server_instance.lua
+++ b/luatest/server_instance.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local fio = require('fio')
 local fun = require('fun')
 local json = require('json')


### PR DESCRIPTION
When luatest is installed as a rock, the internal server_instance.lua
script won't have execution permissions even though it has them in the
source tree, and won't be able to be run while a server start.

Let's start a server process as

    /abs/path/to/tarantool /abs/path/to/luatest/server_instance.lua

instead of just

    /abs/path/to/luatest/server_instance.lua

to bypass the problem.

Also, the shebang string and x-bit are removed from server_instance.lua.

Part of #269