### PR TITLE
Autorequire luatest in server instances

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,6 @@
 include_files = {"**/*.lua", "*.rockspec", "*.luacheckrc"}
 exclude_files = {"lua_modules/", ".luarocks/", ".rocks/", "tmp/"}
 
+globals = {"t"}
+
 max_line_length = 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Print Tarantool version used by luatest.
 - Add new module `replica_proxy.lua`.
 - Add new module `tarantool.lua`.
+- Autorequire `luatest` module in the server instance as `t` variable.
 
 ## 0.5.7
 

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -95,4 +95,8 @@ function luatest.defaults(...)
     return luatest.configure(...)
 end
 
+if not rawget(_G, 't') then
+    rawset(_G, 't', luatest)
+end
+
 return luatest

--- a/test/autorequire_luatest_test.lua
+++ b/test/autorequire_luatest_test.lua
@@ -1,0 +1,116 @@
+local fio = require('fio')
+
+local g = t.group()
+local Server = t.Server
+
+local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
+local datadir = fio.pathjoin(root, 'tmp', 'luatest_module')
+local command = fio.pathjoin(root, 'test', 'server_instance.lua')
+
+g.before_all(function()
+    fio.rmtree(datadir)
+
+    g.server = Server:new({
+        command = command,
+        workdir = fio.pathjoin(datadir, 'common'),
+        env = {
+            LUA_PATH =
+                root .. '/?.lua;' ..
+                root .. '/?/init.lua;' ..
+                root .. '/.rocks/share/tarantool/?.lua'
+        },
+        http_port = 8182,
+        net_box_port = 3133,
+    })
+    fio.mktree(g.server.workdir)
+
+    g.server:start()
+    t.helpers.retrying({timeout = 2}, function()
+        g.server:http_request('get', '/ping')
+    end)
+
+    g.server:connect_net_box()
+end)
+
+g.after_all(function()
+    g.server:stop()
+    fio.rmtree(datadir)
+end)
+
+g.test_exec_without_t = function()
+    local actual = g.server:exec(function()
+        return 1 + 1
+    end)
+    t.assert_equals(actual, 2)
+end
+
+g.test_exec_with_global_variable = function()
+    g.server:exec(function()
+        t.assert_equals(1, 1)
+    end)
+    t.assert_equals(1, 1)
+end
+
+g.test_exec_with_local_variable = function()
+    g.server:exec(function()
+        local t = require('luatest')
+        t.assert_equals(1, 1)
+    end)
+    t.assert_equals(1, 1)
+end
+
+g.test_exec_with_local_duplicate = function()
+    g.server:exec(function()
+        local tt = require('luatest')
+        t.assert_equals(1, 1)
+        tt.assert_equals(1, 1)
+        t.assert_equals(tt, t)
+    end)
+end
+
+g.test_eval_with_t = function()
+    local actual = g.server:eval([[
+        t.assert_equals(1, 1)
+        return 1
+    ]])
+    t.assert_equals(actual, 1)
+end
+
+g.before_test('test_exec_when_lua_path_is_unset', function()
+    -- Setup custom server without LUA_PATH variable
+    local workdir = fio.tempdir()
+    local log = fio.pathjoin(workdir, 'bad_env_server.log')
+    g.bad_env_server = Server:new({
+        command = command,
+        workdir = workdir,
+        env = {
+            TARANTOOL_LOG = log
+        },
+        http_port = 8183,
+        net_box_port = 3134,
+    })
+
+    fio.mktree(g.bad_env_server.workdir)
+
+    g.bad_env_server:start()
+
+    t.helpers.retrying({timeout = 2}, function()
+        g.bad_env_server:http_request('get', '/ping')
+    end)
+
+    g.bad_env_server:connect_net_box()
+end)
+
+g.test_exec_when_lua_path_is_unset = function()
+    g.bad_env_server:exec(function() return 1 + 1 end)
+
+    t.assert(
+        g.bad_env_server:grep_log(
+            "W> LUA_PATH is unset or incorrect, module 'luatest' not found"
+        )
+    )
+end
+
+g.after_test('test_exec_when_lua_path_is_unset', function()
+    g.bad_env_server:drop()
+end)

--- a/test/server_instance.lua
+++ b/test/server_instance.lua
@@ -5,12 +5,14 @@ local json = require('json')
 local workdir = os.getenv('TARANTOOL_WORKDIR')
 local listen = os.getenv('TARANTOOL_LISTEN')
 local http_port = os.getenv('TARANTOOL_HTTP_PORT')
+local log = os.getenv('TARANTOOL_LOG')
 
-box.cfg({work_dir = workdir})
+local httpd = require('http.server').new('0.0.0.0', http_port)
+
+box.cfg({work_dir = workdir, log = log})
 box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists=true})
 box.cfg({listen = listen})
 
-local httpd = require('http.server').new('0.0.0.0', http_port)
 
 httpd:route({path = '/ping', method = 'GET'}, function()
     return {status = 200, body = 'pong'}


### PR DESCRIPTION
Luatest module available without explicit require:

```lua
g.server:exec(function()
   t.assert(...)
end)
```

Resolves #233

- [x] Tests
- [x] Changelog
- [x] Documentation

