### PR TITLE
Fix server start issue when coverage is enabled

### DIFF
--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -292,3 +292,12 @@ g.test_max_unix_socket_path_exceeded = function()
         }
     )
 end
+
+g.test_server_start_with_coverage_enabled = function()
+    t.skip_if(server.coverage_report, 'Coverage is already enabled. Nothing to test')
+    server:restart({coverage_report = true})
+    t.helpers.retrying({}, function() server:connect_net_box() end)
+    t.assert_str_matches(
+        server:exec(function() return box.info.status end), 'running'
+    )
+end


### PR DESCRIPTION
Fix the following error:

    LuajitError: /usr/bin/tarantool:1: unexpected symbol near 'char(127)'
    fatal error, exiting the event loop

Fixes #274
