### PR TITLE
Fix Tarantool restart detection in `Server:grep_log`

### DIFF
--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -641,7 +641,7 @@ function Server:grep_log(pattern, bytes_num, opts)
                     line = table.concat(buf)
                     buf = nil
                 end
-                if string.match(line, 'Tarantool %d+.%d+.%d+-.*%d+-g.*') and reset then
+                if string.match(line, '> Tarantool %d+.%d+.%d+-.*%d+-g.*$') and reset then
                     found = nil -- server was restarted, reset the result
                 else
                     found = string.match(line, pattern) or found


### PR DESCRIPTION
`Server:grep_log` assumes that the Tarantool instance was restarted and resets search if it finds a string matching

`Tarantool %d+.%d+.%d+-.*%d+-g.*`

The problem is the warning message printed by `box.cfg()` if the instance needs a schema upgrade also matches this string:

```
W> Your schema version is 2.10.5 while Tarantool 2.11.0-entrypoint-945-gbd02451ff84d requires a more recent schema version. Please, consider using box.schema.upgrade().
```

[link to the code](https://github.com/tarantool/tarantool/blob/0479cfafc9615bc6eb69442f98735704c3bc5aa0/src/box/lua/load_cfg.lua#L1021-L1031)

Fix the search string to make sure this doesn't happen.

**NO CHANGELOG** because the luatest version where Server:grep_log was first introduced hasn't been released yet.