### PR TITLE
Raise an error when non-array arguments passed to the `server:exec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Auto-require `luatest` module in `Server:exec()` function where it is available
   via the corresponding upvalue.
 - Add new function `tarantool.skip_if_not_enterprise`.
+- Raise an error when non-array arguments passed to the `server:exec()`.
 
 ## 0.5.7
 

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -504,6 +504,19 @@ local function exec_tail(ok, ...)
     end
 end
 
+-- Check that the passed `args` to the `fn` function are an array.
+local function are_fn_args_array(fn, args)
+    local fn_details = debug.getinfo(fn)
+    if args and #args ~= fn_details.nparams then
+        for k, _ in pairs(args) do
+            if type(k) ~= 'number' then
+                return false
+            end
+        end
+    end
+    return true
+end
+
 --- Run given function on the server.
 --
 -- Much like `Server:eval`, but takes a function instead of a string.
@@ -560,6 +573,11 @@ function Server:exec(fn, args, options)
             table.concat(other_ups, ', ')
         )
         error(err, 2)
+    end
+
+    if not are_fn_args_array(fn, args) then
+        error(('bad argument #3 for exec at %s: an array is required')
+            :format(utils.get_fn_location(fn)))
     end
 
     return exec_tail(self.net_box:eval([[

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -142,5 +142,10 @@ function utils.upvalues(fn)
     return ret
 end
 
+function utils.get_fn_location(fn)
+    local fn_details = debug.getinfo(fn)
+    local fn_source = fn_details.source:split('/')
+    return ('%s:%s'):format(fn_source[#fn_source], fn_details.linedefined)
+end
 
 return utils

--- a/test/malformed_args_test.lua
+++ b/test/malformed_args_test.lua
@@ -1,0 +1,80 @@
+local fio = require('fio')
+local t = require('luatest')
+
+local g = t.group()
+local Server = t.Server
+
+local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
+local datadir = fio.pathjoin(root, 'tmp', 'malformed_args')
+local command = fio.pathjoin(root, 'test', 'server_instance.lua')
+
+g.before_all(function()
+    fio.rmtree(datadir)
+
+    local log = fio.pathjoin(datadir, 'malformed_args_server.log')
+    g.server = Server:new({
+        command = command,
+        workdir = datadir,
+        env = {
+            TARANTOOL_LOG = log
+        },
+        http_port = 8186,
+        net_box_port = 3139,
+    })
+    fio.mktree(g.server.workdir)
+
+    g.server:start()
+    t.helpers.retrying({timeout = 2}, function()
+        g.server:http_request('get', '/ping')
+    end)
+
+    g.server:connect_net_box()
+end)
+
+g.after_all(function()
+    g.server:drop()
+    fio.rmtree(datadir)
+end)
+
+g.test_exec_correct_args = function()
+    local a = g.server:exec(function(a, b) return a + b end, {1, 1})
+    t.assert_equals(a, 2)
+end
+
+g.test_exec_no_args = function()
+    local a = g.server:exec(function() return 1 + 1 end)
+    t.assert_equals(a, 2)
+end
+
+g.test_exec_specific_args = function()
+    -- nil
+    local a = g.server:exec(function(a) return a end)
+    t.assert_equals(a, nil)
+
+    -- too few args
+    local b, c = g.server:exec(function(b, c) return b, c end, {1})
+    t.assert_equals(b, 1)
+    t.assert_equals(c, nil)
+
+    -- too many args
+    local d = g.server:exec(function(d) return d end, {1, 2})
+    t.assert_equals(d, 1)
+end
+
+g.test_exec_non_array_args = function()
+    local function f1()
+        g.server:exec(function(a, b, c) return a, b, c end, {a="a", 2, 3})
+    end
+
+    local function f2()
+        g.server:exec(function(a, b, c) return a, b, c end, {1, a="a", 2})
+    end
+
+    local function f3()
+        g.server:exec(function(a, b, c) return a, b, c end, {1, 2, a="a"})
+    end
+
+    t.assert_error_msg_contains("bad argument #3 for exec at malformed_args_test.lua:66:", f1)
+    t.assert_error_msg_contains("bad argument #3 for exec at malformed_args_test.lua:70:", f2)
+    t.assert_error_msg_contains("bad argument #3 for exec at malformed_args_test.lua:74:", f3)
+end


### PR DESCRIPTION
Due to the specifics of the `unpack` function in the `server:exec()` method an array structure check has been added. An error will be raised if the arguments are not an array.

### Normal cases

```lua
-- some_test.lua
server:exec(function(a, b)
    -- `a` is 'a'
    -- `b` is 'b'
end, {'a', 'b'})

server:exec(function()
    -- nothing
end)
```

### Number of items and structure length

Due to the specific and non-deterministic `#` method, we cannot use this table attribute.
These cases will be skipped and will not be checked.

```lua
-- some_test.lua
server:exec(function(a)
    -- nothing
end)

server:exec(function(a,b)
    -- `a` is 'a'
    -- `b` is nil
end, {'a'})

server:exec(function(a)
    -- `a` is 'a'
    --  the rest of the arguments are cut off
end, {'a', 'b'})
```

### Corner case with  shifting arguments

```lua
-- some_test.lua
server:exec(function(a,b,c)
    -- `a` is 'a'
    -- `b` is 'c' (!) shifted
    -- `c` is nil
end, {'a', b='b', 'c'})
```

`Luatest` will give an error:

```
bad argument #3 for exec at malformed_args_test.lua:66: an array is required"
```

- [x] Tests
- [x] Changelog
- [x] Documentation

Resolves #230