### PR TITLE
Add server wrappers for the `box.cfg` interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
     - `Server:wait_for_vclock()`
     - `Server:wait_for_downstream_to()`
     - `Server:wait_for_vclock_of()`
+    - `Server:update_box_cfg()`
+    - `Server:get_box_cfg()`
 - Check docs generation with LDoc.
 - Add `--repeat-group` (`-R`) option to run tests in a circle within the group.
 - Forbid negative values for `--repeat` (`-r`) option.

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -841,4 +841,23 @@ function Server:wait_for_vclock_of(other_server)
     self:wait_for_vclock(vclock)
 end
 
+-- Box configuration
+
+--- A simple wrapper around the `Server:exec()` method
+-- to update the `box.cfg` value on the server.
+--
+-- @tab cfg Box configuration settings.
+function Server:update_box_cfg(cfg)
+    checks('?', 'table')
+    return self:exec(function(c) box.cfg(c) end, {cfg})
+end
+
+--- A simple wrapper around the `Server:exec()` method
+-- to get the `box.cfg` value from the server.
+--
+-- @return table
+function Server:get_box_cfg()
+    return self:exec(function() return box.cfg end)
+end
+
 return Server

--- a/test/boxcfg_interaction_test.lua
+++ b/test/boxcfg_interaction_test.lua
@@ -1,0 +1,92 @@
+local fio = require('fio')
+local t = require('luatest')
+
+local g = t.group()
+local Server = t.Server
+
+local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
+local datadir = fio.pathjoin(root, 'tmp', 'boxcfg_interaction')
+local command = fio.pathjoin(root, 'test', 'server_instance.lua')
+
+g.before_all(function()
+    fio.rmtree(datadir)
+
+    local workdir = fio.tempdir()
+    local log = fio.pathjoin(workdir, 'boxcfg_interaction.log')
+
+    g.server = Server:new({
+        command = command,
+        workdir = fio.pathjoin(datadir, 'boxcfg_interaction'),
+        env = {
+            TARANTOOL_LOG = log
+        },
+        box_cfg = {read_only = false},
+        http_port = 8187,
+        net_box_port = 3138,
+    })
+    fio.mktree(g.server.workdir)
+
+    g.server:start()
+    t.helpers.retrying({timeout = 2}, function()
+        g.server:http_request('get', '/ping')
+    end)
+
+    g.server:connect_net_box()
+end)
+
+g.after_all(function()
+    g.server:drop()
+    fio.rmtree(datadir)
+end)
+
+g.test_update_box_cfg = function()
+    g.server:update_box_cfg{read_only = true}
+
+    local c = g.server:exec(function() return box.cfg end)
+
+    t.assert_type(c, 'table')
+    t.assert_equals(c.read_only, true)
+    t.assert(
+        g.server:grep_log(
+            "I> set 'read_only' configuration option to true"
+        )
+    )
+end
+
+g.test_update_box_cfg_multiple_parameters = function()
+    g.server:update_box_cfg{checkpoint_count = 5, replication_timeout = 2}
+
+    local c = g.server:exec(function() return box.cfg end)
+
+    t.assert_type(c, 'table')
+
+    t.assert_equals(c.checkpoint_count, 5)
+    t.assert(
+        g.server:grep_log(
+            "I> set 'checkpoint_count' configuration option to 5"
+        )
+    )
+
+    t.assert_equals(c.replication_timeout, 2)
+    t.assert(
+        g.server:grep_log(
+            "I> set 'replication_timeout' configuration option to 2"
+        )
+    )
+end
+
+g.test_update_box_cfg_bad_type = function()
+    local function foo()
+        g.server:update_box_cfg(1)
+    end
+    t.assert_error_msg_contains(
+        'bad argument #2 to update_box_cfg (table expected, got number)', foo)
+
+end
+
+g.test_get_box_cfg = function()
+    local cfg1 = g.server:get_box_cfg()
+    local cfg2 = g.server:exec(function() return box.cfg end)
+
+    t.assert_equals(cfg1, cfg2)
+end

--- a/test/server_instance.lua
+++ b/test/server_instance.lua
@@ -5,10 +5,11 @@ local json = require('json')
 local workdir = os.getenv('TARANTOOL_WORKDIR')
 local listen = os.getenv('TARANTOOL_LISTEN')
 local http_port = os.getenv('TARANTOOL_HTTP_PORT')
+local log = os.getenv('TARANTOOL_LOG')
 
 local httpd = require('http.server').new('0.0.0.0', http_port)
 
-box.cfg({work_dir = workdir})
+box.cfg({work_dir = workdir, log = log})
 box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists = true})
 box.cfg({listen = listen})
 


### PR DESCRIPTION
### Description

Server module(`server.lua`)  will contain two new wrappers for the interacting with the `box.cfg` variable on the remote server instance:

`server:update_box_cfg(cfg)`
`server:get_box_cfg()`

### server:update_box_cfg

Performs a simple call to `box.cfg(cfg)` on server instance. `cfg` type must be table. if type is incorrect
will be write the follow error:

```
bad argument #2 to set_box_cfg (table expected, got <your_bad_type>)
```

### server:get_box_cfg

Performs a simple call to `return box.cfg` on server instance. Method does not take parameters. It returns a table.

### Usage

```lua
-- some_test.lua
server:update_box_cfg{read_only=true}

local cfg = server:get_box_cfg()
print(cfg.read_only) -- will printed `true`
```

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #232