### PR TITLE
Improve luatest auto-requiring in `Server:exec`

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,4 @@
 include_files = {"**/*.lua", "*.rockspec", "*.luacheckrc"}
 exclude_files = {"lua_modules/", ".luarocks/", ".rocks/", "tmp/"}
 
-globals = {"t"}
-
 max_line_length = 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
 - Print Tarantool version used by luatest.
 - Add new module `replica_proxy.lua`.
 - Add new module `tarantool.lua`.
-- Autorequire `luatest` module in the server instance as `t` variable.
+- Auto-require `luatest` module in `Server:exec()` function where it is available
+  via the corresponding upvalue.
 
 ## 0.5.7
 

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -95,8 +95,4 @@ function luatest.defaults(...)
     return luatest.configure(...)
 end
 
-if not rawget(_G, 't') then
-    rawset(_G, 't', luatest)
-end
-
 return luatest

--- a/test/server_instance.lua
+++ b/test/server_instance.lua
@@ -5,14 +5,12 @@ local json = require('json')
 local workdir = os.getenv('TARANTOOL_WORKDIR')
 local listen = os.getenv('TARANTOOL_LISTEN')
 local http_port = os.getenv('TARANTOOL_HTTP_PORT')
-local log = os.getenv('TARANTOOL_LOG')
 
 local httpd = require('http.server').new('0.0.0.0', http_port)
 
-box.cfg({work_dir = workdir, log = log})
-box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists=true})
+box.cfg({work_dir = workdir})
+box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists = true})
 box.cfg({listen = listen})
-
 
 httpd:route({path = '/ping', method = 'GET'}, function()
     return {status = 200, body = 'pong'}


### PR DESCRIPTION
In the commit tarantool/luatest@58eae75 auto-requiring of the 'luatest'
lib was added to the `Server:eval()` function, so it was also available
in `Server:exec()`, and it was defined as `t` variable. In the process
of development we found that the following construction doesn't work due
to the upvalue error:

    -- foo_bar_test.lua
    local t = require('luatest')

    ...
    g.test_foo_bar = function()
        server:exec(function()
            t.assert_equals(1, 1)  -- upvalues exception (!)
        end)
    end

To fix this error we decided to make the global variable `t` that had
the 'luatest' lib already loaded. So there was no need to import the
'luatest' lib in the test files and the following example worked:

    -- foo_bar_test.lua
    -- local t = require('luatest')  -- `t` is already defined

    ...
    g.test_foo_bar = function()
        server:exec(function()
            t.assert_equals(1, 1)  -- it works
        end)
    end:

But such an approach is not explicit enough and may mislead developers.
So it was decided to improve and extend the existing mechanism. Now we
just make the needed upvalue with the 'luatest' lib inside available in
the `Server:exec()` function via some magic. And now we can do something
like this:

    -- foo_bar_test.lua
    local t1 = require('luatest')
    local t2 = require('luatest')

    ...
    g.test_foo_bar_1 = function()
        server:exec(function()
            t1.assert_equals(1, 1)  -- it works
        end)
    end

    g.test_foo_bar_2 = function()
        server:exec(function()
            t2.assert_equals(1, 1)  -- it works
        end)
    end

Unfortunately, we cannot do the same for the `Server:eval()` function
and now it becomes just a shortcut for `Server.net_box:eval()` as it
was before the first version of auto-requiring of the 'luatest' lib.

Follows up #277
In scope of #233