### PR TITLE
Raise an error in the `Server:wait_for_condition()` function when the server process is terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
   via the corresponding upvalue.
 - Add new function `tarantool.skip_if_not_enterprise`.
 - Raise an error when non-array arguments passed to the `server:exec()`.
+- Raise an error in the `Server:wait_for_condition()` function when
+  the server process is terminated. This is useful to not wait for timeout, for example,
+  when a server fails to start due to bad configuration.
 
 ## 0.5.7
 

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -301,3 +301,32 @@ g.test_server_start_with_coverage_enabled = function()
         server:exec(function() return box.info.status end), 'running'
     )
 end
+
+g.test_wait_when_server_is_not_running_by_bad_option = function()
+    local s1 = Server:new({
+        box_cfg = {
+            bad_option = 'bad'
+        }
+    })
+    local s2 = Server:new({
+        box_cfg = {
+            replication = {
+                'bad_uri'
+            }
+        }
+    })
+
+    local expected_msg = 'Process is terminated when waiting for "server is ready"'
+
+    local status, msg = pcall(Server.start, s1)
+    t.assert_equals(status, false)
+    t.assert_str_contains(msg, expected_msg)
+    t.assert_equals(s1.process:is_alive(), false)
+    s1:clean()
+
+    status, msg = pcall(Server.start, s2)
+    t.assert_equals(status, false)
+    t.assert_str_contains(msg, expected_msg)
+    t.assert_equals(s2.process:is_alive(), false)
+    s2:clean()
+end


### PR DESCRIPTION
### Description

There is a simple test via replica set:
```lua
-- some_test.lua
local cluster = require('luatest.replica_set')
cluster:new()

cluster:build_server(master, ...)
cluster:build_server(replica, ...)

cluster:add_server(master)
cluster:add_server(replica)

cluster:start()
```
This works fine if all servers are successfully started.
However, luatest will wait all the time (60s by default), even if something has happened to the process.

See the diagram for details:

![luatest-replica drawio](https://user-images.githubusercontent.com/20374223/218128829-423bbda8-62e5-4513-b41f-103cc1a7233a.png)

### Solution

Add process status check to waiting for condition:

```lua
-- server.lua
...
local function wait_for_condition(cond_desc, server, func, ...)
   ...
    while true do
        if not server.process:is_alive() then -- checks state of process
            ...
        end
        if fund(...) then
            return
        end
        if clock.time() > deadline then -- checks time
            ...
        end
        fiber.sleep(WAIT_DELAY)
    end
end
```
There is no need for a long wait now. If the process did not start or died, it will be output:

Case from #275: 
```
-- luatest stdout
-- box_cfg contains `bad_option`

server | ER_CFG: Incorrect value for option 'bad_option': unexpected option
server | fatal error, exiting the event loop
**without delay**
luatest/luatest/server.lua:330: Process is dead or not started for "server is ready" condition for server (alias: server, workdir: server-4WoRaGFYBphB, pid: 69541)
```

Case from #224:
```
-- luatest stdout
-- box_cfg.replication contains `bad_uri`

server | ER_CFG: Incorrect value for option 'replication': bad URI 'bad_uri': expected host:service or /unix.socket
server | fatal error, exiting the event loop
**without delay too*
luatest/luatest/server.lua:330: Process is dead or not started for "server is ready" condition for server (alias: server, workdir: server-yb7-ROmYDh77, pid: 70358)
```

- [x] Tests
- [x] Changelog
- [x] Documentation

Resolve #275, #224