### PR TITLE
Keep artifacts of server(logs, snap, etc) if test  has been failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
   * Add waiting until the process of the stopped server is terminated.
   * Add new functions:
     - `Server.build_listen_uri()`
-    - `Server:clean()`
     - `Server:drop()`
     - `Server:wait_until_ready()`
     - `Server:get_instance_id()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 - Raise an error in the `Server:wait_for_condition()` function when
   the server process is terminated. This is useful to not wait for timeout, for example,
   when a server fails to start due to bad configuration.
+- Save server artifacts (logs, snapshots, etc.) if the test fails.
+- Group the working directory of servers into a replica set.
 
 ## 0.5.7
 

--- a/luatest/output/junit.lua
+++ b/luatest/output/junit.lua
@@ -23,13 +23,17 @@ function Output.node_status_xml(node)
     if node:is('error') then
         return table.concat(
             {'            <error type="', Output.xml_escape(node.message), '">\n',
-             '                <![CDATA[', Output.xml_c_data_escape(node.trace),
-             ']]></error>\n'})
+            '                <![CDATA[', Output.xml_c_data_escape(node.trace),']]>\n',
+            '                <artifacts>', Output.xml_escape(node.artifacts),
+            '                </artifacts>\n',
+            '            </error>\n'})
     elseif node:is('fail') then
         return table.concat(
             {'            <failure type="', Output.xml_escape(node.message), '">\n',
-             '                <![CDATA[', Output.xml_c_data_escape(node.trace),
-             ']]></failure>\n'})
+             '                <![CDATA[', Output.xml_c_data_escape(node.trace),']]>\n',
+             '                <artifacts>', Output.xml_escape(node.artifacts),
+             '                </artifacts>\n',
+             '            </failure>\n'})
     elseif node:is('skip') then
         return table.concat({'            <skipped>', Output.xml_escape(node.message or ''),'</skipped>\n'})
     end

--- a/luatest/output/tap.lua
+++ b/luatest/output/tap.lua
@@ -28,6 +28,7 @@ function Output.mt:update_status(node)
     end
     if (node:is('fail') or node:is('error')) and self.verbosity >= self.class.VERBOSITY.VERBOSE then
        print(prefix .. node.trace:gsub('\n', '\n' .. prefix))
+       print(prefix .. node.artifacts .. prefix)
     end
 end
 

--- a/luatest/output/text.lua
+++ b/luatest/output/text.lua
@@ -57,8 +57,11 @@ function Output.mt:end_test(node)
 end
 
 function Output.mt:display_one_failed_test(index, fail) -- luacheck: no unused
-    print(index..") " .. fail.name .. self.class.ERROR_COLOR_CODE)
-    print(fail.message .. self.class.RESET_TERM)
+    print(index..") " .. fail.name)
+    if fail.logs ~= nil then
+        print(self.class.WARN_COLOR_CODE .. "Test artifacts:\n" .. fail.logs .. self.class.ERROR_COLOR_CODE)
+    end
+    print(self.class.ERROR_COLOR_CODE .. fail.message .. self.class.RESET_TERM)
     print(fail.trace)
     print()
 end

--- a/luatest/output/text.lua
+++ b/luatest/output/text.lua
@@ -57,12 +57,10 @@ function Output.mt:end_test(node)
 end
 
 function Output.mt:display_one_failed_test(index, fail) -- luacheck: no unused
-    print(index..") " .. fail.name)
-    if fail.logs ~= nil then
-        print(self.class.WARN_COLOR_CODE .. "Test artifacts:\n" .. fail.logs .. self.class.ERROR_COLOR_CODE)
-    end
-    print(self.class.ERROR_COLOR_CODE .. fail.message .. self.class.RESET_TERM)
+    print(index..") " .. fail.name .. self.class.ERROR_COLOR_CODE)
+    print(fail.message .. self.class.RESET_TERM)
     print(fail.trace)
+    print(fail.artifacts)
     print()
 end
 

--- a/luatest/replica_set.lua
+++ b/luatest/replica_set.lua
@@ -169,19 +169,10 @@ function ReplicaSet:stop()
     end
 end
 
---- Clean working directories of all servers in the replica set.
--- Should be invoked only for a stopped replica set.
-function ReplicaSet:clean()
-    for _, server in ipairs(self.servers) do
-        server:clean()
-    end
-end
-
 --- Stop all servers in the replica set and clean their working directories.
 function ReplicaSet:drop()
     for _, server in ipairs(self.servers) do
-        server:stop()
-        server:clean()
+        server:drop()
     end
 end
 

--- a/luatest/replica_set.lua
+++ b/luatest/replica_set.lua
@@ -59,15 +59,9 @@ end
 function ReplicaSet:initialize()
     self._server = Server
 
-    if self.alias == nil then
-        self.alias = ('rs-%s'):format(utils.generate_id())
-    end
-
-    if self.workdir == nil then
-        self.workdir = fio.pathjoin(Server.vardir, self.alias)
-        fio.rmtree(self.workdir)
-        fio.mktree(self.workdir)
-    end
+    self.alias = 'rs'
+    self.id = ('%s-%s'):format(self.alias, utils.generate_id())
+    self.workdir = fio.pathjoin(self._server.vardir, self.id)
 
     if self.servers then
         local configs = table.deepcopy(self.servers)
@@ -86,10 +80,8 @@ end
 -- @return table
 -- @see luatest.server:new
 function ReplicaSet:build_server(config)
-    checks('table', self._server.constructor_checks)
-    config.vardir = self.workdir
     if config then config = table.deepcopy(config) end
-    return self._server:new(config)
+    return self._server:new(config, {rs_id = self.id})
 end
 
 --- Add the server object to the replica set.
@@ -186,7 +178,7 @@ end
 --- Stop all servers in the replica set and clean their working directories.
 function ReplicaSet:drop()
     for _, server in ipairs(self.servers) do
-        server:drop({replica_set=self.alias})
+        server:drop()
     end
     fio.rmtree(self.workdir)
 end

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -423,6 +423,7 @@ function Runner.mt:run_tests(tests_list)
                 self:start_group(test.group)
                 last_group = test.group
             end
+            rawset(_G, 'current_test', test)
             self:run_test(test)
             if self.result.aborted then
                 break

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -416,6 +416,7 @@ function Runner.mt:run_tests(tests_list)
     for _ = 1, self.exe_repeat_group or 1 do
         local last_group
         for _, test in ipairs(tests_list) do
+            rawset(_G, 'current_test', test)
             if last_group ~= test.group then
                 if last_group then
                     self:end_group(last_group)
@@ -423,7 +424,6 @@ function Runner.mt:run_tests(tests_list)
                 self:start_group(test.group)
                 last_group = test.group
             end
-            rawset(_G, 'current_test', test)
             self:run_test(test)
             if self.result.aborted then
                 break

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -358,18 +358,13 @@ function Server:stop()
     end
 end
 
---- Clean the server's working directory.
--- Should be invoked only for a stopped server.
-function Server:clean()
-    fio.rmtree(self.workdir)
-    self.instance_id = nil
-    self.instance_uuid = nil
-end
-
 --- Stop the server and clean its working directory.
 function Server:drop()
     self:stop()
-    self:clean()
+
+    fio.rmtree(self.workdir)
+    self.instance_id = nil
+    self.instance_uuid = nil
 end
 
 --- Wait until the server is ready after the start.

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -362,6 +362,17 @@ end
 function Server:drop()
     self:stop()
 
+    local current_test = rawget(_G, 'current_test')
+    if not current_test:is('success') then
+        local artifacts = fio.pathjoin(self.vardir, ('artifacts/%s-%s'):format(self.alias, self.id))
+
+        local ok, err = fio.copytree(self.workdir, artifacts)
+        if not ok then
+            error(('Failed to copy directory: %s'):format(err))
+        end
+        current_test:add_server_artifacts_directory(self.alias, artifacts)
+    end
+
     fio.rmtree(self.workdir)
     self.instance_id = nil
     self.instance_uuid = nil

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -33,6 +33,7 @@ local Server = {
     constructor_checks = {
         command = '?string',
         workdir = '?string',
+        vardir  = '?string',
         datadir = '?string',
         chdir = '?string',
         env = '?table',
@@ -359,12 +360,17 @@ function Server:stop()
 end
 
 --- Stop the server and clean its working directory.
-function Server:drop()
+function Server:drop(opts)
+    opts = opts or {}
+
     self:stop()
 
+    local replica_set = opts.replica_set or ''
     local current_test = rawget(_G, 'current_test')
+    local prefix = fio.pathjoin(Server.vardir, 'artifacts', replica_set)
+
     if not current_test:is('success') then
-        local artifacts = fio.pathjoin(self.vardir, ('artifacts/%s-%s'):format(self.alias, self.id))
+        local artifacts = fio.pathjoin(prefix, ('%s-%s'):format(self.alias, self.id))
 
         local ok, err = fio.copytree(self.workdir, artifacts)
         if not ok then

--- a/luatest/test_instance.lua
+++ b/luatest/test_instance.lua
@@ -24,6 +24,15 @@ function TestInstance.mt:update_status(status, message, trace)
     self.trace = trace
 end
 
+function TestInstance.mt:add_server_artifacts_directory(alias, workdir)
+    local formatted_str = string.format('\t%s -> %s\n', alias, workdir)
+    if self.logs ~= nil then
+        self.logs = self.logs .. formatted_str
+    else
+        self.logs = formatted_str
+    end
+end
+
 function TestInstance.mt:is(status)
     return self.status == status
 end

--- a/luatest/test_instance.lua
+++ b/luatest/test_instance.lua
@@ -16,6 +16,7 @@ end
 -- default constructor, test are PASS by default
 function TestInstance.mt:initialize()
     self.status = 'success'
+    self.artifacts = 'server artifacts:\n'
 end
 
 function TestInstance.mt:update_status(status, message, trace)
@@ -25,12 +26,8 @@ function TestInstance.mt:update_status(status, message, trace)
 end
 
 function TestInstance.mt:add_server_artifacts_directory(alias, workdir)
-    local formatted_str = string.format('\t%s -> %s\n', alias, workdir)
-    if self.logs ~= nil then
-        self.logs = self.logs .. formatted_str
-    else
-        self.logs = formatted_str
-    end
+    local prepared_str = string.format('#\t%s -> %s\n', alias, workdir)
+    self.artifacts = self.artifacts .. prepared_str
 end
 
 function TestInstance.mt:is(status)

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -1,5 +1,6 @@
 local fun = require('fun')
 local yaml = require('yaml')
+local digest = require('digest')
 
 local utils = {}
 
@@ -146,6 +147,12 @@ function utils.get_fn_location(fn)
     local fn_details = debug.getinfo(fn)
     local fn_source = fn_details.source:split('/')
     return ('%s:%s'):format(fn_source[#fn_source], fn_details.linedefined)
+end
+
+function utils.generate_id(length, urlsafe)
+    urlsafe = urlsafe or true
+    length = length or 9
+    return digest.base64_encode(digest.urandom(length), {urlsafe = urlsafe})
 end
 
 return utils

--- a/test/collect_rs_artifacts_test.lua
+++ b/test/collect_rs_artifacts_test.lua
@@ -1,0 +1,107 @@
+local fio = require('fio')
+local t = require('luatest')
+local utils = require('luatest.utils')
+local ReplicaSet = require('luatest.replica_set')
+
+local g = t.group()
+local Server = t.Server
+
+local function build_specific_replica_set(alias_suffix)
+    local box_cfg = {
+        replication_timeout = 0.1,
+        replication_connect_timeout = 1,
+        replication_sync_lag = 0.01,
+        replication_connect_quorum = 3,
+    }
+
+    local s1_alias = ('replica1-%s'):format(alias_suffix)
+    local s2_alias = ('replica2-%s'):format(alias_suffix)
+    local s3_alias = ('replica3-%s'):format(alias_suffix)
+
+    box_cfg = utils.merge(
+        table.deepcopy(box_cfg),
+        {
+            replication ={
+            Server.build_listen_uri(s1_alias),
+            Server.build_listen_uri(s2_alias),
+            Server.build_listen_uri(s3_alias)
+    }})
+    local rs = ReplicaSet:new()
+
+    rs:build_and_add_server({alias = s1_alias, box_cfg = box_cfg})
+    rs:build_and_add_server({alias = s2_alias, box_cfg = box_cfg})
+    rs:build_and_add_server({alias = s3_alias, box_cfg = box_cfg})
+    return rs
+end
+
+local function get_replica_set_artifacts_path(rs)
+    return ('%s/artifacts/%s'):format(rs._server.vardir, rs.id)
+end
+
+local function get_server_artifacts_path_by_alias(rs, position, alias_node)
+    local rs_artifacts = get_replica_set_artifacts_path(rs)
+    return ('%s/%s'):format(
+        rs_artifacts,
+        rs:get_server(('%s-%s'):format(position, alias_node).id))
+end
+
+local function assert_artifacts_paths(rs, alias_suffix)
+    t.assert_equals(fio.path.exists(get_replica_set_artifacts_path(rs)), true)
+    t.assert_equals(fio.path.is_dir(get_replica_set_artifacts_path(rs)), true)
+
+    t.assert_equals(
+        fio.path.exists(get_server_artifacts_path_by_alias(rs, 1, alias_suffix)), true)
+    t.assert_equals(
+        fio.path.is_dir(get_server_artifacts_path_by_alias(rs, 1, alias_suffix)), true)
+
+    t.assert_equals(
+        fio.path.exists(get_server_artifacts_path_by_alias(rs, 2, alias_suffix)), true)
+    t.assert_equals(
+        fio.path.is_dir(get_server_artifacts_path_by_alias(rs, 2, alias_suffix)), true)
+
+    t.assert_equals(
+        fio.path.exists(get_server_artifacts_path_by_alias(rs, 3, alias_suffix)), true)
+    t.assert_equals(
+        fio.path.is_dir(get_server_artifacts_path_by_alias(rs, 3, alias_suffix)), true)
+end
+
+g.before_all(function()
+    g.rs_all = build_specific_replica_set('all')
+
+    g.rs_all:start()
+    g.rs_all:wait_for_fullmesh()
+end)
+
+g.before_each(function()
+    g.rs_each = build_specific_replica_set('each')
+
+    g.rs_each:start()
+    g.rs_each:wait_for_fullmesh()
+end)
+
+g.before_test('test_foo', function()
+    g.rs_test = build_specific_replica_set('test')
+
+    g.rs_test:start()
+    g.rs_test:wait_for_fullmesh()
+end)
+
+g.test_foo = function()
+    t.xfail()
+    t.assert_equals(1, 2)
+end
+
+g.after_test('test_foo', function()
+    g.rs_test:drop()
+    assert_artifacts_paths(g.rs_each, 'test')
+end)
+
+g.after_each(function()
+    g.rs_each:drop()
+    assert_artifacts_paths(g.rs_each, 'each')
+end)
+
+g.after_all(function()
+    g.rs_all:drop()
+    assert_artifacts_paths(g.rs_each, 'all')
+end)

--- a/test/collect_server_artifacts_test.lua
+++ b/test/collect_server_artifacts_test.lua
@@ -1,0 +1,68 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local g = t.group()
+
+local Server = t.Server
+
+local function get_server_artifacts_path(s)
+    return ('%s/%s'):format(s.vardir, s.id)
+end
+
+local function assert_artifacts_path(s)
+    t.assert_equals(fio.path.exists(get_server_artifacts_path(s)), true)
+    t.assert_equals(fio.path.is_dir(get_server_artifacts_path(s)), true)
+end
+
+g.before_all(function()
+    g.s_all  = Server:new({alias = 'all'})
+    g.s_all2 = Server:new({alias = 'all2'})
+
+    g.s_all:start()
+    g.s_all2:start()
+end)
+
+g.before_each(function()
+    g.s_each  = Server:new({alias = 'each'})
+    g.s_each2 = Server:new({alias = 'each2'})
+
+    g.s_each:start()
+    g.s_each2:start()
+end)
+
+g.before_test('test_foo', function()
+    g.s_test  = Server:new({alias = 'test'})
+    g.s_test2 = Server:new({alias = 'test2'})
+
+    g.s_test:start()
+    g.s_test2:start()
+end)
+
+g.test_foo = function()
+    t.xfail()
+    t.assert_equals(1, 2)
+end
+
+g.after_test('test_foo', function()
+    g.s_test:drop()
+    g.s_test2:drop()
+
+    assert_artifacts_path(g.s_test)
+    assert_artifacts_path(g.s_test2)
+end)
+
+g.after_each(function()
+    g.s_each:drop()
+    g.s_each2:drop()
+
+    assert_artifacts_path(g.s_each)
+    assert_artifacts_path(g.s_each2)
+end)
+
+g.after_all(function()
+    g.s_all:drop()
+    g.s_all2:drop()
+
+    assert_artifacts_path(g.s_all)
+    assert_artifacts_path(g.s_all2)
+end)

--- a/test/replica_set_test.lua
+++ b/test/replica_set_test.lua
@@ -5,8 +5,8 @@ local ReplicaSet = require('luatest.replica_set')
 local g = t.group()
 local Server = t.Server
 
-g.before_each(function()
-    local box_cfg = {
+g.before_all(function()
+    g.box_cfg = {
         replication_timeout = 0.1,
         replication_connect_timeout = 10,
         replication_sync_lag = 0.01,
@@ -15,32 +15,28 @@ g.before_each(function()
             Server.build_listen_uri('replica1'),
             Server.build_listen_uri('replica2'),
             Server.build_listen_uri('replica3'),
-        },
+        }
     }
-    g.s1 = Server:new({alias = 'replica1', box_cfg = box_cfg})
-    g.s2 = Server:new({alias = 'replica2', box_cfg = box_cfg})
-    g.s3 = Server:new({alias = 'replica3', box_cfg = box_cfg})
+end)
 
-    g.replica_set = ReplicaSet:new({})
-    g.replica_set:add_server(g.s1)
-    g.replica_set:add_server(g.s2)
-    g.replica_set:add_server(g.s3)
+g.before_test('test_save_rs_artifacts_when_test_failed', function()
+    g.rs = ReplicaSet:new()
 
+    g.rs:build_and_add_server({alias = 'replica1', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({alias = 'replica2', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({alias = 'replica3', box_cfg = g.box_cfg})
 
-    g.replica_set:start()
-    g.replica_set:wait_for_fullmesh()
-
-    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.replica_set.alias)
-    g.s1_artifacts = ('%s/%s-%s'):format(g.rs_artifacts, g.s1.alias, g.s1.id)
-    g.s2_artifacts = ('%s/%s-%s'):format(g.rs_artifacts, g.s2.alias, g.s2.id)
-    g.s3_artifacts = ('%s/%s-%s'):format(g.rs_artifacts, g.s3.alias, g.s3.id)
+    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.rs.id)
+    g.s1_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica1').id)
+    g.s2_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica2').id)
+    g.s3_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica3').id)
 end)
 
 g.test_save_rs_artifacts_when_test_failed = function()
     local test = rawget(_G, 'current_test')
     -- the test must be failed to save artifacts
     test.status = 'fail'
-    g.replica_set:drop()
+    g.rs:drop()
     test.status = 'success'
 
     t.assert_equals(fio.path.exists(g.rs_artifacts), true)
@@ -56,8 +52,59 @@ g.test_save_rs_artifacts_when_test_failed = function()
     t.assert_equals(fio.path.is_dir(g.s3_artifacts), true)
 end
 
-g.test_remove_rs_artifacts_when_test_success = function()
-    g.replica_set:drop()
+g.before_test('test_save_rs_artifacts_when_server_workdir_passed', function()
+    g.rs = ReplicaSet:new()
 
-    t.assert_equals(fio.path.exists(g.replica_set.workdir), false)
+    local s1_workdir = ('%s/%s'):format(Server.vardir, os.tmpname())
+    local s2_workdir = ('%s/%s'):format(Server.vardir, os.tmpname())
+    local s3_workdir = ('%s/%s'):format(Server.vardir, os.tmpname())
+
+    g.rs:build_and_add_server({workdir = s1_workdir, alias = 'replica1', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({workdir = s2_workdir, alias = 'replica2', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({workdir = s3_workdir, alias = 'replica3', box_cfg = g.box_cfg})
+
+    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.rs.id)
+    g.s1_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica1').id)
+    g.s2_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica2').id)
+    g.s3_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica3').id)
+end)
+
+g.test_save_rs_artifacts_when_server_workdir_passed = function()
+    local test = rawget(_G, 'current_test')
+    -- the test must be failed to save artifacts
+    test.status = 'fail'
+    g.rs:drop()
+    test.status = 'success'
+
+    t.assert_equals(fio.path.exists(g.rs_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.rs_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s1_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s1_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s2_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s2_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s3_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s3_artifacts), true)
+
+end
+
+g.before_test('test_remove_rs_artifacts_when_test_success', function()
+    g.rs = ReplicaSet:new()
+
+    g.rs:build_and_add_server({alias = 'replica1', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({alias = 'replica2', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({alias = 'replica3', box_cfg = g.box_cfg})
+
+    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.rs.id)
+    g.s1_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica1').id)
+    g.s2_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica2').id)
+    g.s3_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica3').id)
+end)
+
+g.test_remove_rs_artifacts_when_test_success = function()
+    g.rs:drop()
+
+    t.assert_equals(fio.path.exists(g.rs.workdir), false)
 end

--- a/test/replica_set_test.lua
+++ b/test/replica_set_test.lua
@@ -1,0 +1,63 @@
+local fio = require('fio')
+local t = require('luatest')
+local ReplicaSet = require('luatest.replica_set')
+
+local g = t.group()
+local Server = t.Server
+
+g.before_each(function()
+    local box_cfg = {
+        replication_timeout = 0.1,
+        replication_connect_timeout = 10,
+        replication_sync_lag = 0.01,
+        replication_connect_quorum = 3,
+        replication = {
+            Server.build_listen_uri('replica1'),
+            Server.build_listen_uri('replica2'),
+            Server.build_listen_uri('replica3'),
+        },
+    }
+    g.s1 = Server:new({alias = 'replica1', box_cfg = box_cfg})
+    g.s2 = Server:new({alias = 'replica2', box_cfg = box_cfg})
+    g.s3 = Server:new({alias = 'replica3', box_cfg = box_cfg})
+
+    g.replica_set = ReplicaSet:new({})
+    g.replica_set:add_server(g.s1)
+    g.replica_set:add_server(g.s2)
+    g.replica_set:add_server(g.s3)
+
+
+    g.replica_set:start()
+    g.replica_set:wait_for_fullmesh()
+
+    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.replica_set.alias)
+    g.s1_artifacts = ('%s/%s-%s'):format(g.rs_artifacts, g.s1.alias, g.s1.id)
+    g.s2_artifacts = ('%s/%s-%s'):format(g.rs_artifacts, g.s2.alias, g.s2.id)
+    g.s3_artifacts = ('%s/%s-%s'):format(g.rs_artifacts, g.s3.alias, g.s3.id)
+end)
+
+g.test_save_rs_artifacts_when_test_failed = function()
+    local test = rawget(_G, 'current_test')
+    -- the test must be failed to save artifacts
+    test.status = 'fail'
+    g.replica_set:drop()
+    test.status = 'success'
+
+    t.assert_equals(fio.path.exists(g.rs_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.rs_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s1_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s1_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s2_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s2_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s3_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s3_artifacts), true)
+end
+
+g.test_remove_rs_artifacts_when_test_success = function()
+    g.replica_set:drop()
+
+    t.assert_equals(fio.path.exists(g.replica_set.workdir), false)
+end

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -323,9 +323,32 @@ g.test_wait_when_server_is_not_running_by_bad_option = function()
     t.assert_str_contains(msg, expected_msg)
     t.assert_equals(s1.process:is_alive(), false)
 
-
     status, msg = pcall(Server.start, s2)
     t.assert_equals(status, false)
     t.assert_str_contains(msg, expected_msg)
     t.assert_equals(s2.process:is_alive(), false)
+end
+
+g.test_save_server_artifacts_when_test_failed = function()
+    local s = Server:new()
+    s:start()
+
+    local artifacts = ('%s/artifacts/%s-%s'):format(s.vardir, s.alias, s.id)
+    local test = rawget(_G, 'current_test')
+
+    -- the test must be failed to save artifacts
+    test.status = 'fail'
+    s:drop()
+    test.status = 'success'
+
+    t.assert_equals(fio.path.exists(artifacts), true)
+    t.assert_equals(fio.path.is_dir(artifacts), true)
+end
+
+g.test_remove_server_artifacts_when_test_success = function()
+    local s = Server:new()
+    s:start()
+    s:drop()
+
+    t.assert_equals(fio.path.exists(s.workdir), false)
 end

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -322,11 +322,10 @@ g.test_wait_when_server_is_not_running_by_bad_option = function()
     t.assert_equals(status, false)
     t.assert_str_contains(msg, expected_msg)
     t.assert_equals(s1.process:is_alive(), false)
-    s1:clean()
+
 
     status, msg = pcall(Server.start, s2)
     t.assert_equals(status, false)
     t.assert_str_contains(msg, expected_msg)
     t.assert_equals(s2.process:is_alive(), false)
-    s2:clean()
 end


### PR DESCRIPTION
### :large_blue_circle: Description
#### :heavy_minus_sign: 1. Remove the `server:clean()` method

The method was removed because there was an ambiguous understanding of the differences between the `stop()`, `drop()` and `clean()` methods.

Now, there are only two method:

- `drop()` - stops and perfoms a clean-up working directory of server object;
- `stop()` -  stops the server process and closes the connection.

#### :heavy_minus_sign:  2. Save server logs if test has been failed

If the test fails, all server artifacts (logs, xlogs, snapshots, etc.) will be saved to the `/artifacts` directory for further analysis.

Default path for the test artifacts is `/tmp/t/artifacts`.

How it will works:

- the test must contain any hook that calls the `server:drop()` method;
- if test has been failed, server performs:
  - copy all server artifacts to the specific directory in the artifacts (`tmp/t/artifacts` by default);
  - if the copy was successful, delete the working directory of the server
  - if not, raise an error.

####  :heavy_minus_sign:  3. Group server work directory by replica set

Group the artifacts of cluster nodes for more convenient analysis after the tests fall.
By default, replicaset artifacts will be located in the `/tmp/t/artifacts/<replica-set/<nodes>` directory. 

To do this, we added  `alias` and `workdir` of replica set.

####  :heavy_minus_sign:  `extra` Improve output printing for easier artifact search

Now, if you use server or replica set objects and your test fails, the console output will contain information about artifacts:

```lua
-- test/foo_test.lua
g.foo = function()
    g.s1 = Server:new()
    g.s1:start()
    g.s2 = Server:new()
    g.s2:start()
    g.tom = Server:new({alias='tom'})
    g.tom:start()
    ...
    t.assert_equals(true, false)
end

g.after_test('foo', function(g)
  g.s1:drop()
  -- your artifacts here: /tmp/t/artifacts/server-XXXX
  g.s2:drop()
  -- your artifacts here: /tmp/t/artifacts/server-YYYY
  g.tom:drop()
  -- your artifacts here: /tmp/t/artifacts/tom-AAAA
end)
```

Output:

```
Failed tests:
-------------

1) foo/test_foo
Test artifacts:
	server -> /tmp/t/artifacts/server-o38ZZc2MbytD
	server -> /tmp/t/artifacts/server-00rY556LuYaJ
        tom -> /tmp/t/artifacts/tom-d88qzzopMPWW

/home/pc/workspace/luatest///test/server_test.lua:365: expected: false, actual: true
stack traceback:
	...
	[C]: in function 'xpcall'

Ran 20 tests in 2.036 seconds, 19 succeeded, 1 failed
```

Just run:

```bash
$ ls /tmp/t/artifacts/server-o38ZZc2MbytD
00000000000000000000.snap  00000000000000000001.xlog
00000000000000000000.xlog  server.log
```

### :large_blue_circle: Examples

####  :heavy_minus_sign:  Server

```lua
-- test/foo_test.lua
g.foo = function()
    g.s = Server:new()
    g.tom = Server:new({alias = 'tom'})
    g.s:start() -- e.g. `s` label is `server-XXXX`
    g.tom:start() -- `tom-XXXX`
    ...
end

g.after_test('foo', function(g)
  g.s:drop() -- artifacts: /tmp/t/artifacts/server-XXXX
  g.tom:drop() -- artifacts: /tmp/t/artifacts/tom-XXXX
end)
```

####  :heavy_minus_sign:  Replica set

```lua
-- test/foo_test.lua
g.foo = function()
    ...
    g.replica_set = ReplicaSet:new() -- `rs-ZZZZ`
    g.replica_set:add_server(foo) -- `foo-XXXX`
    g.replica_set:add_server(bar) -- `bar-YYYY`

    g.replica_set2 = ReplicaSet:new({alias='fullmesh'})
    g.replica_set2:add_server(foo) -- `foo-XXXX`
    g.replica_set2:add_server(bar) -- `bar-YYYY`
    ...
end

g.after_test('foo', function(g)
  g.replica_set:drop()
  -- your artifacts here:
  --     /tmp/t/artifacts/rs-ZZZZ/foo-XXXX
  --     /tmp/t/artifacts/rs-ZZZZ/bar-YYYY

 g.replica_set2:drop()
  -- your artifacts here:
  --     /tmp/t/artifacts/fullmesh/foo-XXXX
  --     /tmp/t/artifacts/fullmesh/bar-YYYY

end)
```


- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #253 #197
