### PR TITLE
Keep artifacts of server(logs, snap, etc) if test has been failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
   * Add waiting until the process of the stopped server is terminated.
   * Add new functions:
     - `Server.build_listen_uri()`
-    - `Server:clean()`
     - `Server:drop()`
     - `Server:wait_until_ready()`
     - `Server:get_instance_id()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 - Raise an error in the `Server:wait_for_condition()` function when
   the server process is terminated. This is useful to not wait for timeout, for example,
   when a server fails to start due to bad configuration.
+- Save server artifacts (logs, snapshots, etc.) if the test fails.
+- Group working directories of servers inside a replica set into one directory.
 
 ## 0.5.7
 

--- a/luatest/output/junit.lua
+++ b/luatest/output/junit.lua
@@ -23,13 +23,15 @@ function Output.node_status_xml(node)
     if node:is('error') then
         return table.concat(
             {'            <error type="', Output.xml_escape(node.message), '">\n',
-             '                <![CDATA[', Output.xml_c_data_escape(node.trace),
-             ']]></error>\n'})
+             '                <![CDATA[', Output.xml_c_data_escape(node.trace), ']]>\n',
+             '                <artifacts>', Output.xml_escape(node.artifacts or ''), '</artifacts>\n',
+             '            </error>\n'})
     elseif node:is('fail') then
         return table.concat(
             {'            <failure type="', Output.xml_escape(node.message), '">\n',
-             '                <![CDATA[', Output.xml_c_data_escape(node.trace),
-             ']]></failure>\n'})
+             '                <![CDATA[', Output.xml_c_data_escape(node.trace), ']]>\n',
+             '                <artifacts>', Output.xml_escape(node.artifacts or ''), '</artifacts>\n',
+             '            </failure>\n'})
     elseif node:is('skip') then
         return table.concat({'            <skipped>', Output.xml_escape(node.message or ''),'</skipped>\n'})
     end

--- a/luatest/output/tap.lua
+++ b/luatest/output/tap.lua
@@ -24,10 +24,13 @@ function Output.mt:update_status(node)
     io.stdout:write("not ok ", node.serial_number, "\t", node.name, "\n")
     local prefix = '#   '
     if self.verbosity > self.class.VERBOSITY.QUIET then
-       print(prefix .. node.message:gsub('\n', '\n' .. prefix))
+        print(prefix .. node.message:gsub('\n', '\n' .. prefix))
     end
     if (node:is('fail') or node:is('error')) and self.verbosity >= self.class.VERBOSITY.VERBOSE then
-       print(prefix .. node.trace:gsub('\n', '\n' .. prefix))
+        print(prefix .. node.trace:gsub('\n', '\n' .. prefix))
+        if node.artifacts then
+            print(prefix .. node.artifacts:gsub('\n', '\n' .. prefix))
+        end
     end
 end
 

--- a/luatest/output/text.lua
+++ b/luatest/output/text.lua
@@ -60,6 +60,9 @@ function Output.mt:display_one_failed_test(index, fail) -- luacheck: no unused
     print(index..") " .. fail.name .. self.class.ERROR_COLOR_CODE)
     print(fail.message .. self.class.RESET_TERM)
     print(fail.trace)
+    if fail.artifacts then
+        print(fail.artifacts)
+    end
     print()
 end
 

--- a/luatest/replica_set.lua
+++ b/luatest/replica_set.lua
@@ -169,19 +169,10 @@ function ReplicaSet:stop()
     end
 end
 
---- Clean working directories of all servers in the replica set.
--- Should be invoked only for a stopped replica set.
-function ReplicaSet:clean()
-    for _, server in ipairs(self.servers) do
-        server:clean()
-    end
-end
-
 --- Stop all servers in the replica set and clean their working directories.
 function ReplicaSet:drop()
     for _, server in ipairs(self.servers) do
-        server:stop()
-        server:clean()
+        server:drop()
     end
 end
 

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -416,6 +416,7 @@ function Runner.mt:run_tests(tests_list)
     for _ = 1, self.exe_repeat_group or 1 do
         local last_group
         for _, test in ipairs(tests_list) do
+            rawset(_G, 'current_test', test)
             if last_group ~= test.group then
                 if last_group then
                     self:end_group(last_group)

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -4,7 +4,6 @@
 
 local checks = require('checks')
 local clock = require('clock')
-local digest = require('digest')
 local errno = require('errno')
 local fiber = require('fiber')
 local fio = require('fio')
@@ -92,10 +91,13 @@ end
 --   `net.box` connection to the new server.
 -- @tab[opt] object.box_cfg Extra options for `box.cfg()` and the value of the
 --   `TARANTOOL_BOX_CFG` env variable which is passed into the server process.
+-- @tab[opt] extra Table with extra properties for the server object.
 -- @return table
-function Server:new(object)
-    checks('table', self.constructor_checks)
+function Server:new(object, extra)
+    checks('table', self.constructor_checks, '?table')
     if not object then object = {} end
+    if not extra then extra = {} end
+    object = utils.merge(object, extra)
     self:inherit(object)
     object:initialize()
     return object
@@ -103,12 +105,12 @@ end
 
 -- Initialize the server object.
 function Server:initialize()
-    if self.id == nil then
-        self.id = digest.base64_encode(digest.urandom(9), {urlsafe = true})
-    end
-
     if self.alias == nil then
         self.alias = DEFAULT_ALIAS
+    end
+
+    if self.id == nil then
+        self.id = ('%s-%s'):format(self.alias, utils.generate_id())
     end
 
     if self.command == nil then
@@ -116,10 +118,10 @@ function Server:initialize()
     end
 
     if self.workdir == nil then
-        self.workdir = fio.pathjoin(self.vardir, ('%s-%s'):format(self.alias, self.id))
+        self.workdir = fio.pathjoin(self.vardir, self.id)
         fio.rmtree(self.workdir)
-        fio.mktree(self.workdir)
     end
+    fio.mktree(self.workdir)
 
     if self.datadir ~= nil then
         local ok, err = fio.copytree(self.datadir, self.workdir)
@@ -182,6 +184,15 @@ function Server:initialize()
         -- values set with os.setenv are not available with os.environ
         -- so set it explicitly:
         self.env.LUATEST_LUACOV_ROOT = os.getenv('LUATEST_LUACOV_ROOT')
+    end
+
+    if self.current_test == nil then
+        self.current_test = rawget(_G, 'current_test')
+        if self.current_test then
+            local prefix = fio.pathjoin(Server.vardir, 'artifacts', self.rs_id or '')
+            self.artifacts = fio.pathjoin(prefix, self.id)
+            self.current_test:add_server_artifacts(self.alias, self.artifacts)
+        end
     end
 end
 
@@ -361,6 +372,13 @@ end
 --- Stop the server and clean its working directory.
 function Server:drop()
     self:stop()
+
+    if self.current_test and not self.current_test:is('success') then
+        local ok, err = fio.copytree(self.workdir, self.artifacts)
+        if not ok then
+            error(('Failed to copy server artifacts: %s'):format(err))
+        end
+    end
 
     fio.rmtree(self.workdir)
 

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -345,7 +345,7 @@ function Server:stop()
         self.net_box = nil
     end
 
-    if self.process then
+    if self.process and self.process:is_alive() then
         self.process:kill()
         local ok, err = pcall(wait_for_condition, 'process is terminated', self, function()
             return not self.process:is_alive()

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -358,18 +358,14 @@ function Server:stop()
     end
 end
 
---- Clean the server's working directory.
--- Should be invoked only for a stopped server.
-function Server:clean()
-    fio.rmtree(self.workdir)
-    self.instance_id = nil
-    self.instance_uuid = nil
-end
-
 --- Stop the server and clean its working directory.
 function Server:drop()
     self:stop()
-    self:clean()
+
+    fio.rmtree(self.workdir)
+
+    self.instance_id = nil
+    self.instance_uuid = nil
 end
 
 --- Wait until the server is ready after the start.

--- a/luatest/test_instance.lua
+++ b/luatest/test_instance.lua
@@ -16,12 +16,21 @@ end
 -- default constructor, test are PASS by default
 function TestInstance.mt:initialize()
     self.status = 'success'
+    self.artifacts = nil
 end
 
 function TestInstance.mt:update_status(status, message, trace)
     self.status = status
     self.message = message
     self.trace = trace
+end
+
+function TestInstance.mt:add_server_artifacts(alias, workdir)
+    local server_workdir = string.format('\n\t%s -> %s', alias, workdir)
+    if not self.artifacts then
+        self.artifacts = 'artifacts:'
+    end
+    self.artifacts = self.artifacts .. server_workdir
 end
 
 function TestInstance.mt:is(status)

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -1,3 +1,4 @@
+local digest = require('digest')
 local fun = require('fun')
 local yaml = require('yaml')
 
@@ -146,6 +147,12 @@ function utils.get_fn_location(fn)
     local fn_details = debug.getinfo(fn)
     local fn_source = fn_details.source:split('/')
     return ('%s:%s'):format(fn_source[#fn_source], fn_details.linedefined)
+end
+
+function utils.generate_id(length, urlsafe)
+    if not length then length = 9 end
+    if urlsafe == nil then urlsafe = true end
+    return digest.base64_encode(digest.urandom(length), {urlsafe = urlsafe})
 end
 
 return utils

--- a/test/collect_rs_artifacts_test.lua
+++ b/test/collect_rs_artifacts_test.lua
@@ -1,0 +1,101 @@
+local fio = require('fio')
+local t = require('luatest')
+local utils = require('luatest.utils')
+local ReplicaSet = require('luatest.replica_set')
+
+local g = t.group()
+local Server = t.Server
+
+local function build_specific_replica_set(alias_suffix)
+    local box_cfg = {
+        replication_timeout = 0.1,
+        replication_connect_timeout = 1,
+        replication_sync_lag = 0.01,
+        replication_connect_quorum = 3,
+    }
+
+    local s1_alias = ('replica1-%s'):format(alias_suffix)
+    local s2_alias = ('replica2-%s'):format(alias_suffix)
+    local s3_alias = ('replica3-%s'):format(alias_suffix)
+
+    box_cfg = utils.merge(
+        table.deepcopy(box_cfg),
+        {
+            replication ={
+            Server.build_listen_uri(s1_alias),
+            Server.build_listen_uri(s2_alias),
+            Server.build_listen_uri(s3_alias)
+    }})
+    local rs = ReplicaSet:new()
+
+    rs:build_and_add_server({alias = s1_alias, box_cfg = box_cfg})
+    rs:build_and_add_server({alias = s2_alias, box_cfg = box_cfg})
+    rs:build_and_add_server({alias = s3_alias, box_cfg = box_cfg})
+    return rs
+end
+
+local function get_replica_set_artifacts_path(rs)
+    return ('%s/artifacts/%s'):format(rs._server.vardir, rs.id)
+end
+
+local function get_server_artifacts_path_by_alias(rs, position, alias_node)
+    local rs_artifacts = get_replica_set_artifacts_path(rs)
+    return ('%s/%s'):format(
+        rs_artifacts,
+        rs:get_server(('replica%s-%s'):format(position, alias_node)).id)
+end
+
+local function assert_artifacts_paths(rs, alias_suffix)
+    t.assert_equals(fio.path.exists(get_replica_set_artifacts_path(rs)), true)
+    t.assert_equals(fio.path.is_dir(get_replica_set_artifacts_path(rs)), true)
+
+    t.assert_equals(
+        fio.path.exists(get_server_artifacts_path_by_alias(rs, 1, alias_suffix)), true)
+    t.assert_equals(
+        fio.path.is_dir(get_server_artifacts_path_by_alias(rs, 1, alias_suffix)), true)
+
+    t.assert_equals(
+        fio.path.exists(get_server_artifacts_path_by_alias(rs, 2, alias_suffix)), true)
+    t.assert_equals(
+        fio.path.is_dir(get_server_artifacts_path_by_alias(rs, 2, alias_suffix)), true)
+
+    t.assert_equals(
+        fio.path.exists(get_server_artifacts_path_by_alias(rs, 3, alias_suffix)), true)
+    t.assert_equals(
+        fio.path.is_dir(get_server_artifacts_path_by_alias(rs, 3, alias_suffix)), true)
+end
+
+g.before_all(function()
+    g.rs_all = build_specific_replica_set('all')
+
+    g.rs_all:start()
+    g.rs_all:wait_for_fullmesh()
+end)
+
+g.before_each(function()
+    g.rs_each = build_specific_replica_set('each')
+
+    g.rs_each:start()
+    g.rs_each:wait_for_fullmesh()
+end)
+
+g.before_test('test_foo', function()
+    g.rs_test = build_specific_replica_set('test')
+
+    g.rs_test:start()
+    g.rs_test:wait_for_fullmesh()
+end)
+
+g.test_foo = function()
+    local test = rawget(_G, 'current_test')
+
+    test.status = 'fail'
+    g.rs_test:drop()
+    g.rs_each:drop()
+    g.rs_all:drop()
+    test.status = 'success'
+
+    assert_artifacts_paths(g.rs_test, 'test')
+    assert_artifacts_paths(g.rs_each, 'each')
+    assert_artifacts_paths(g.rs_all, 'all')
+end

--- a/test/collect_server_artifacts_test.lua
+++ b/test/collect_server_artifacts_test.lua
@@ -1,0 +1,55 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local g = t.group()
+
+local Server = t.Server
+
+local function assert_artifacts_path(s)
+    t.assert_equals(fio.path.exists(s.artifacts), true)
+    t.assert_equals(fio.path.is_dir(s.artifacts), true)
+end
+
+g.before_all(function()
+    g.s_all  = Server:new({alias = 'all'})
+    g.s_all2 = Server:new({alias = 'all2'})
+
+    g.s_all:start()
+    g.s_all2:start()
+end)
+
+g.before_each(function()
+    g.s_each  = Server:new({alias = 'each'})
+    g.s_each2 = Server:new({alias = 'each2'})
+
+    g.s_each:start()
+    g.s_each2:start()
+end)
+
+g.before_test('test_foo', function()
+    g.s_test  = Server:new({alias = 'test'})
+    g.s_test2 = Server:new({alias = 'test2'})
+
+    g.s_test:start()
+    g.s_test2:start()
+end)
+
+g.test_foo = function()
+    local test = rawget(_G, 'current_test')
+
+    test.status = 'fail'
+    g.s_test:drop()
+    g.s_test2:drop()
+    g.s_each:drop()
+    g.s_each2:drop()
+    g.s_all:drop()
+    g.s_all2:drop()
+    test.status = 'success'
+
+    assert_artifacts_path(g.s_test)
+    assert_artifacts_path(g.s_test2)
+    assert_artifacts_path(g.s_each)
+    assert_artifacts_path(g.s_each2)
+    assert_artifacts_path(g.s_all)
+    assert_artifacts_path(g.s_all2)
+end

--- a/test/replica_set_test.lua
+++ b/test/replica_set_test.lua
@@ -1,0 +1,110 @@
+local fio = require('fio')
+local t = require('luatest')
+local ReplicaSet = require('luatest.replica_set')
+
+local g = t.group()
+local Server = t.Server
+
+g.before_all(function()
+    g.box_cfg = {
+        replication_timeout = 0.1,
+        replication_connect_timeout = 10,
+        replication_sync_lag = 0.01,
+        replication_connect_quorum = 3,
+        replication = {
+            Server.build_listen_uri('replica1'),
+            Server.build_listen_uri('replica2'),
+            Server.build_listen_uri('replica3'),
+        }
+    }
+end)
+
+g.before_test('test_save_rs_artifacts_when_test_failed', function()
+    g.rs = ReplicaSet:new()
+
+    g.rs:build_and_add_server({alias = 'replica1', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({alias = 'replica2', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({alias = 'replica3', box_cfg = g.box_cfg})
+
+    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.rs.id)
+    g.s1_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica1').id)
+    g.s2_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica2').id)
+    g.s3_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica3').id)
+end)
+
+g.test_save_rs_artifacts_when_test_failed = function()
+    local test = rawget(_G, 'current_test')
+    -- the test must be failed to save artifacts
+    test.status = 'fail'
+    g.rs:drop()
+    test.status = 'success'
+
+    t.assert_equals(fio.path.exists(g.rs_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.rs_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s1_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s1_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s2_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s2_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s3_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s3_artifacts), true)
+end
+
+g.before_test('test_save_rs_artifacts_when_server_workdir_passed', function()
+    g.rs = ReplicaSet:new()
+
+    local s1_workdir = ('%s/%s'):format(Server.vardir, os.tmpname())
+    local s2_workdir = ('%s/%s'):format(Server.vardir, os.tmpname())
+    local s3_workdir = ('%s/%s'):format(Server.vardir, os.tmpname())
+
+    g.rs:build_and_add_server({workdir = s1_workdir, alias = 'replica1', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({workdir = s2_workdir, alias = 'replica2', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({workdir = s3_workdir, alias = 'replica3', box_cfg = g.box_cfg})
+
+    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.rs.id)
+    g.s1_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica1').id)
+    g.s2_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica2').id)
+    g.s3_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica3').id)
+end)
+
+g.test_save_rs_artifacts_when_server_workdir_passed = function()
+    local test = rawget(_G, 'current_test')
+    -- the test must be failed to save artifacts
+    test.status = 'fail'
+    g.rs:drop()
+    test.status = 'success'
+
+    t.assert_equals(fio.path.exists(g.rs_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.rs_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s1_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s1_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s2_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s2_artifacts), true)
+
+    t.assert_equals(fio.path.exists(g.s3_artifacts), true)
+    t.assert_equals(fio.path.is_dir(g.s3_artifacts), true)
+
+end
+
+g.before_test('test_remove_rs_artifacts_when_test_success', function()
+    g.rs = ReplicaSet:new()
+
+    g.rs:build_and_add_server({alias = 'replica1', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({alias = 'replica2', box_cfg = g.box_cfg})
+    g.rs:build_and_add_server({alias = 'replica3', box_cfg = g.box_cfg})
+
+    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.rs.id)
+    g.s1_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica1').id)
+    g.s2_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica2').id)
+    g.s3_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica3').id)
+end)
+
+g.test_remove_rs_artifacts_when_test_success = function()
+    g.rs:drop()
+
+    t.assert_equals(fio.path.exists(g.rs.workdir), false)
+end

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -322,13 +322,13 @@ g.test_wait_when_server_is_not_running_by_bad_option = function()
     t.assert_equals(status, false)
     t.assert_str_contains(msg, expected_msg)
     t.assert_equals(s1.process:is_alive(), false)
-    s1:clean()
+    s1:drop()
 
     status, msg = pcall(Server.start, s2)
     t.assert_equals(status, false)
     t.assert_str_contains(msg, expected_msg)
     t.assert_equals(s2.process:is_alive(), false)
-    s2:clean()
+    s2:drop()
 end
 
 g.test_drop_server_if_process_is_dead = function()

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -343,3 +343,36 @@ g.test_drop_server_if_process_is_dead = function()
 
     s:drop()
 end
+
+g.test_save_server_artifacts_when_test_failed = function()
+    local s1 = Server:new() -- empty config
+    local s2 = Server:new({
+        workdir = ('%s/%s'):format(Server.vardir, os.tmpname())}) -- workdir passed
+
+    s1:start()
+    s2:start()
+
+    local s1_artifacts = ('%s/artifacts/%s'):format(s1.vardir, s1.id)
+    local s2_artifacts = ('%s/artifacts/%s'):format(s2.vardir, s2.id)
+    local test = rawget(_G, 'current_test')
+
+    -- the test must be failed to save artifacts
+    test.status = 'fail'
+    s1:drop()
+    s2:drop()
+    test.status = 'success'
+
+    t.assert_equals(fio.path.exists(s1_artifacts), true)
+    t.assert_equals(fio.path.is_dir(s1_artifacts), true)
+
+    t.assert_equals(fio.path.exists(s2_artifacts), true)
+    t.assert_equals(fio.path.is_dir(s2_artifacts), true)
+end
+
+g.test_remove_server_artifacts_when_test_success = function()
+    local s = Server:new()
+    s:start()
+    s:drop()
+
+    t.assert_equals(fio.path.exists(s.workdir), false)
+end

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -330,3 +330,16 @@ g.test_wait_when_server_is_not_running_by_bad_option = function()
     t.assert_equals(s2.process:is_alive(), false)
     s2:clean()
 end
+
+g.test_drop_server_if_process_is_dead = function()
+    local s = Server:new({
+        box_cfg = {
+            bad_option = 'bad'
+        }
+    })
+    local status, _ = pcall(Server.start, s)
+    t.assert_equals(status, false)
+    t.assert_equals(s.process:is_alive(), false)
+
+    s:drop()
+end


### PR DESCRIPTION
### :large_blue_circle: Description

#### :heavy_minus_sign: 1. Not fail `server:drop()` if the process is already dead

Fixed the following error:

```lua
g.test_foo = function()
    s = Server:new({box_cfg = {bad_option}}
    s:start()  -- bad `box_cfg` value, the server process not started
    s:drop()  -- kill failed: 256
end
```

#### :heavy_minus_sign: 2. Remove the `server:clean()` method

The method was removed because there was an ambiguous understanding of the differences between the `stop()`, `drop()` and `clean()` methods.

Now, there are only two method:

- `drop()` - stops and perfoms a clean-up working directory of server object;
- `stop()` -  stops the server process and closes the connection.

#### :heavy_minus_sign:  3. Save server artifacts if test has been failed

If the test fails, all server artifacts (logs, xlogs, snapshots, etc.) will be saved to the `${VARDIR}/artifacts` directory for further analysis.

Default path for the test artifacts is `${VARDIR}/artifacts`.

How it will work:

- the test must contain any hook that calls the `server:drop()` method;
- if the test has been failed, server performs:
  - copy all server artifacts to the specific directory in the artifacts (`${VARDIR}/artifacts` by default);
  - if the copy was successful, delete the working directory of the server
     - else, raise an error.

```lua
-- test/foo_test.lua
g.before_test('foo', function()
    g.s1 = Server:new()
    g.s1:start()
    
    g.s2 = Server:new()
    g.s2:start()
    
    g.tom = Server:new({alias='tom'})
    g.tom:start()
end)

g.foo = function()
    t.assert_equals(true, false)
end

g.after_test('foo', function(g)
  g.s1:drop()
  -- your artifacts here: /tmp/t/artifacts/server-XXXX
  g.s2:drop()
  -- your artifacts here: /tmp/t/artifacts/server-YYYY
  g.tom:drop()
  -- your artifacts here: /tmp/t/artifacts/tom-AAAA
end)
```

####  :heavy_minus_sign:  4. Group server artifacts by replica set

Group the artifacts of replica set nodes for more convenient analysis after the tests fall.
By default, replica set artifacts will be located in the `${VARDIR}/artifacts/<replica-set/<nodes>` directory. 

####  :heavy_minus_sign:  `extra` Improve output printing for easier artifact search

Now, if you use server or replica set objects and your test fails, the console output will contain information about artifacts:

```
1) test_foo
stack traceback:
	...
	[C]: in function 'xpcall'
artifacts:
        <your_server_id> -> <your_path_to_server>
```

Just run:
```bash
$ ls <your_path_to_server>
00000000000000000000.snap  00000000000000000001.xlog
00000000000000000000.xlog  server.log
```

### :large_blue_circle: Examples

####  :heavy_minus_sign:  Server

See [test file](https://github.com/tarantool/luatest/blob/c9099bcd12128ebdc95fd64523f232bb854bcb27/test/collect_server_artifacts_test.lua#L17-L68)
```
1) collect_server_artifacts.test_foo
.../test/collect_server_artifacts_test.lua:42: expected: 2, actual: 1
stack traceback:
	...
	[C]: in function 'xpcall'
artifacts:
        all -> /tmp/t/artifacts/all-uKlsxAzscx5j
        all2 -> /tmp/t/artifacts/all2-g6cXoEkYUJL4
        each -> /tmp/t/artifacts/each-zRqrRmohkFro
        each2 -> /tmp/t/artifacts/each2-RvIefa3OIOu9
        test -> /tmp/t/artifacts/test-98d0AcfFoCJK
        test2 -> /tmp/t/artifacts/test2-la0zsKAeXsMX
```

####  :heavy_minus_sign:  Replica set

See [test file](https://github.com/tarantool/luatest/blob/c9099bcd12128ebdc95fd64523f232bb854bcb27/test/collect_rs_artifacts_test.lua)
```
1) collect_rs_artifacts.test_foo
..//test/collect_rs_artifacts_test.lua:91: expected: 2, actual: 1
stack traceback:
	...
	[C]: in function 'xpcall'
artifacts:
        replica1-all -> /tmp/t/artifacts/rs-nBfYcSkqz0HT/replica1-all-CKdeW4mKLJFl
        replica2-all -> /tmp/t/artifacts/rs-nBfYcSkqz0HT/replica2-all-ENptNk1o_Fpj
        replica3-all -> /tmp/t/artifacts/rs-nBfYcSkqz0HT/replica3-all-0po6gxYbb89j
        replica1-each -> /tmp/t/artifacts/rs-q8sxJKJuXZP3/replica1-each-gFcMfRMmdgC8
        replica2-each -> /tmp/t/artifacts/rs-q8sxJKJuXZP3/replica2-each-dS784hZBDtky
        replica3-each -> /tmp/t/artifacts/rs-q8sxJKJuXZP3/replica3-each-EWoIn5aSxVCT
        replica1-test -> /tmp/t/artifacts/rs-tLfVvFFuLYbK/replica1-test-2nL7XNt5fOGa
        replica2-test -> /tmp/t/artifacts/rs-tLfVvFFuLYbK/replica2-test-UN6eMW8Xb2NU
        replica3-test -> /tmp/t/artifacts/rs-tLfVvFFuLYbK/replica3-test-swDWCTzTN8gA
```

####  :heavy_minus_sign: Corner case with `before_all` hook

If the `before_all` hook fails, one of the tests from your test group will contain the output containing artifacts.

```lua
g.before_all(function()
    g.s = Server:new()
    g.s:start()
    t.assert_equals(1, 2) -- Boom!
end)

g.test_foo = function()
    t.assert_equals(1, 1) -- success
end 

g.test_bar = function()
    t.assert_equals(1, 1) -- success
end 

g.after_all(function()
    g.s:drop()
end)
```

Output:
```
Failed tests:
-------------

1) collect_server_artifacts.test_bar
//test/collect_server_artifacts_test.lua:18: expected: 2, actual: 1
stack traceback:
	...
	[C]: in function 'xpcall'
artifacts:
	all -> /tmp/t/artifacts/all-bqyAIZtJpOIh

2) collect_server_artifacts.test_foo
//test/collect_server_artifacts_test.lua:18: expected: 2, actual: 1
stack traceback:
	...
	[C]: in function 'xpcall'

```
#####  :heavy_minus_sign: For now we have non-deterministic behavior (#292) in the following case:

```lua
g.before_all(function()
    g.s = Server:new()
    g.s:start()
end)

g.test_bar = function()
    t.assert_equals(1, 2)
end

g.test_foo = function()
end

g.after_all(function()
    g.s:drop()
end)
```
If we are **lucky** with the sequence of running tests, then we will be able to see the artifacts.

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #253
Close #197
Close #292