### PR TITLE
Fix wait_for_downstream_to

### DIFF
--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -858,12 +858,13 @@ function Server:wait_for_vclock(vclock)
     end
 end
 
---- Wait until all own data is replicated and confirmed by the given server.
+--- Wait for the given server to reach at least the same vclock as the local
+-- server. Not including the local component, of course.
 --
 -- @tab server Server's object.
 function Server:wait_for_downstream_to(server)
     local id = server:get_instance_id()
-    local vclock = server:get_vclock()
+    local vclock = self:get_vclock()
     vclock[0] = nil  -- first component is for local changes
     while true do
         if vclock_ge(self:get_downstream_vclock(id), vclock) then


### PR DESCRIPTION
Currently `wait_for_downstream` doesn't wait for replica to be up to date with master. It only checks, that downstream "knows" correct vclock of the replica by taking vclock of remote server and waiting for info.downstream.vclock to be the same. The function's comment says the opposite, so this is not expected behavior.

Let's take current vclock instead. This way the function will wait for remote server to apply all master's data and downstream to be up to date. Moreover, let's update function's comment to be less vague.

Closes tarantool/tarantool-qa#311
