### PR TITLE
Support --script in Tarantool 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
   when a server fails to start due to bad configuration.
 - Save server artifacts (logs, snapshots, etc.) if the test fails.
 - Group working directories of servers inside a replica set into one directory.
+- Support --script option introduced in Tarantool 3.0.
 
 ## 0.5.7
 

--- a/bin/luatest
+++ b/bin/luatest
@@ -1,4 +1,4 @@
-#!/usr/bin/env tarantool
+#!/usr/bin/env -S tarantool --script
 
 print(('Tarantool version is %s'):format(require('tarantool').version))
 

--- a/luatest/tarantool.lua
+++ b/luatest/tarantool.lua
@@ -9,6 +9,18 @@ local assertions = require('luatest.assertions')
 
 local M = {}
 
+--- Return major, minor and patch Tarantool versions.
+function M.version()
+    local major_minor_patch = _G._TARANTOOL:split('-', 1)[1]
+    local major_minor_patch_parts = major_minor_patch:split('.', 2)
+
+    local major = tonumber(major_minor_patch_parts[1])
+    local minor = tonumber(major_minor_patch_parts[2])
+    local patch = tonumber(major_minor_patch_parts[3])
+
+    return major, minor, patch
+end
+
 --- Return true if Tarantool build type is Debug.
 function M.is_debug_build()
     return tarantool.build.target:endswith('-Debug')


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #???


**Depends on** commit with `---script` support, https://github.com/tarantool/tarantool/issues/8612