### PR TITLE
Not require own test helper when running tests

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -33,4 +33,4 @@ jobs:
         run: make lint
 
       - name: Run tests
-        run: bin/luatest -v
+        run: bin/luatest -v --shuffle group

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ add_custom_target(doc
 )
 
 add_custom_target(lint DEPENDS bootstrap COMMAND .rocks/bin/luacheck .)
-add_custom_target(selftest DEPENDS bootstrap COMMAND bin/luatest)
+add_custom_target(selftest DEPENDS bootstrap COMMAND bin/luatest --shuffle group)
 
 add_custom_target(test_with_coverage_report
   DEPENDS bootstrap

--- a/test/assertions_test.lua
+++ b/test/assertions_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 
 g.test_custom_errors = function()
     local function assert_no_exception(fn)

--- a/test/autorequire_luatest_test.lua
+++ b/test/autorequire_luatest_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 local Server = t.Server
 
-local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
+local root = fio.dirname(fio.abspath('test.helpers'))
 local datadir = fio.pathjoin(root, 'tmp', 'luatest_module')
 local command = fio.pathjoin(root, 'test', 'server_instance.lua')
 

--- a/test/boxcfg_interaction_test.lua
+++ b/test/boxcfg_interaction_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 local Server = t.Server
 
-local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
+local root = fio.dirname(fio.abspath('test.helpers'))
 local datadir = fio.pathjoin(root, 'tmp', 'boxcfg_interaction')
 local command = fio.pathjoin(root, 'test', 'server_instance.lua')
 

--- a/test/capturing_test.lua
+++ b/test/capturing_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 local Capture = require('luatest.capture')
 local capture = Capture:new()
 

--- a/test/helpers/general.lua
+++ b/test/helpers/general.lua
@@ -2,8 +2,6 @@ local t = require('luatest')
 local Runner = require('luatest.runner')
 local utils = require('luatest.utils')
 
-t.configure({shuffle = 'group'})
-
 local helper = {}
 
 function helper.run_suite(load_tests, args)

--- a/test/hooks_test.lua
+++ b/test/hooks_test.lua
@@ -2,7 +2,7 @@ local t = require('luatest')
 local g = t.group()
 
 local Capture = require('luatest.capture')
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 
 g.test_hooks = function()
     local hooks = {}

--- a/test/luatest_test.lua
+++ b/test/luatest_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 
 g.test_assert_returns_velue = function()
     t.assert_equals(t.assert(1), 1)

--- a/test/luaunit/assertions_error_test.lua
+++ b/test/luaunit/assertions_error_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 local assert_failure = helper.assert_failure
 local assert_failure_equals = helper.assert_failure_equals
 

--- a/test/luaunit/assertions_test.lua
+++ b/test/luaunit/assertions_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 local assert_failure = helper.assert_failure
 local assert_failure_contains = helper.assert_failure_contains
 

--- a/test/luaunit/error_msg_test.lua
+++ b/test/luaunit/error_msg_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 local assert_failure_matches = helper.assert_failure_matches
 local assert_failure_contains = helper.assert_failure_contains
 local assert_failure_equals = helper.assert_failure_equals

--- a/test/luaunit/utility_test.lua
+++ b/test/luaunit/utility_test.lua
@@ -5,7 +5,7 @@ local fun = require('fun')
 local Runner = require('luatest.runner')
 local utils = require('luatest.utils')
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 local assert_failure_matches = helper.assert_failure_matches
 
 local function range(start, stop)

--- a/test/malformed_args_test.lua
+++ b/test/malformed_args_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group()
 local Server = t.Server
 
-local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
+local root = fio.dirname(fio.abspath('test.helpers'))
 local datadir = fio.pathjoin(root, 'tmp', 'malformed_args')
 local command = fio.pathjoin(root, 'test', 'server_instance.lua')
 

--- a/test/output_test.lua
+++ b/test/output_test.lua
@@ -4,7 +4,7 @@ local g = t.group()
 local Capture = require('luatest.capture')
 local capture = Capture:new()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 
 g.setup = function() capture:enable() end
 g.teardown = function()

--- a/test/parametrization_test.lua
+++ b/test/parametrization_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 
 g.test_validation = function()
     t.assert_error_msg_contains(

--- a/test/pp_test.lua
+++ b/test/pp_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 local clock = require('clock')
 
 local pp = require('luatest.pp')

--- a/test/runner_test.lua
+++ b/test/runner_test.lua
@@ -5,7 +5,7 @@ local fio = require('fio')
 local uuid = require('uuid')
 
 local Capture = require('luatest.capture')
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 
 g.test_run_pass = function()
     local result = helper.run_suite(function(lu2)

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -8,7 +8,7 @@ local utils = require('luatest.utils')
 local Process = t.Process
 local Server = t.Server
 
-local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
+local root = fio.dirname(fio.abspath('test.helpers'))
 local datadir = fio.pathjoin(root, 'tmp', 'db_test')
 local command = fio.pathjoin(root, 'test', 'server_instance.lua')
 

--- a/test/xfail_test.lua
+++ b/test/xfail_test.lua
@@ -1,7 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
-local helper = require('test.helper')
+local helper = require('test.helpers.general')
 
 g.test_failed = function()
     local result = helper.run_suite(function(lu2)


### PR DESCRIPTION
> Fow what test/helper.lua is needed?

Luatest automatically requires `test/helper.lua` file if it's present.
Usually, it is used to configure luatest or run any bootstrap code.

> What's the problem?

To run tarantool functional tests we use the test-run framework [1].
test-run has an integration with luatest (uses luatest as a submodule)
and allows us to run tarantool functional tests written in the luatest
approach. Most of the such tests can be run via luatest directly, but
test-run is used to run all types of tarantool tests at the same time
(diff, python, app, luatest).

When test-run works, it tunes some environment variables for own needs
and sets LUA_PATH to something like this:

    LUA_PATH='<...>/tarantool/?/init.lua;<...>/tarantool/?.lua;\
        <...>/tarantool/test-run/lib/luatest/?/init.lua;\
        <...>/tarantool/test-run/lib/luatest/?.lua;;'

The tarantool tests don't have own `test/helper.lua` file and this file
is required from the luatest submodule of test-run in accordance with
the configured LUA_PATH variable, which is obviously wrong.

> What's the solution?

The simplest way to resolve this issue is to move `test/helper.lua` to
`test/helpers/general.lua` to not auto-require it while running tests.

Actually, there is no reason to have `test/helper.lua` in luatest. I can
assume it was added to run unit tests with `shuffle = 'group'`. But we
can run unit tests with the `--shuffle group` option and have the same
effect.

[1] https://github.com/tarantool/test-run

Closes https://github.com/tarantool/luatest/issues/306