### PR TITLE
Fix detect tarantool crash at exit

### DIFF
--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -367,6 +367,17 @@ function Server:stop()
         if not ok and not err:find('Process is terminated when waiting for') then
             error(err)
         end
+        if self.process.output_beautifier.stderr:find('Segmentation fault') then
+            error(
+                ('Segmentation fault during process termination (alias: %s, workdir: %s, pid: %d)\n%s')
+                :format(
+                    self.alias,
+                    fio.basename(self.workdir),
+                    self.process.pid,
+                    self.process.output_beautifier.stderr
+                )
+            )
+        end
         log.debug('Killed server process PID ' .. self.process.pid)
         self.process = nil
     end


### PR DESCRIPTION
### What's the problem?

During the shutdown of the server, the server process is polled. If the call `ffi.C.kill(<pid>, 0)` returns the value 0, then the process will be considered alive, otherwise it will be dead.

Luatest cannot distinguish the states when the process is completed correctly and incorrectly. This means that if a critical error appears at the end of the process (e.g., segmentation fault), then stopping the server will be considered successful (and the test-case too).

See sequence diagram for the more details:
> FYI: `par` section - parallel activity

![luatest_start_stop_crash](https://github.com/tarantool/luatest/assets/20374223/d91b2587-bf4a-4e27-8d91-7ed5d31cbe44)


### What's the solution?

Possible solutions:

1. rewrite the process.lua module to the popen library (not in our case, see comments for more details tarantool/luatest#124);
2. **check the stderr of the process when the server is stopped.**

The second option was chosen.

Each process contains its own instance of output_beautifier (which reads **stdout** and **stderr**). Now this instance will contain the stderr field (string type) where the entire **stderr** from the process will be saved.

During the server shutdown, it looks for the substring `segmentation fault` and return an error if the substring is found:

```
Failure in after_all hook: ...ace/tarantool/test-run/lib/luatest/luatest/server.lua:371: Segmentation fault during process termination (alias: master, workdir: master-SrQjEIiLyRHS, pid: 152323)
Segmentation fault
  code: SEGV_MAPERR
  addr: (nil)
  context: 0x7feac9f7f800
  siginfo: 0x7feac9f7f930
  rax      0x0                0
  rbx      0x5600ebb0024d     94561954169421
  rcx      0x5600ebb4e703     94561954490115
  rdx      0x5600eb8708fb     94561951484155
  rsi      0x0                0
  rdi      0x0                0
  rsp      0x7feac9f7fec0     140646387547840
  rbp      0x7feac9f7fed0     140646387547856
  r8       0x7e000            516096
  r9       0x7feae5619280     140646847451776
  r10      0x0                0
  r11      0x246              582
  r12      0x0                0
  r13      0x0                0
  r14      0x0                0
  r15      0x0                0
  rip      0x5600eb870910     94561951484176
  eflags   0x10206            66054
  cs       0x33               51
  gs       0x0                0
  fs       0x0                0
  cr2      0x0                0
  err      0x6                6
  oldmask  0x0                0
  trapno   0xe                14
Current time: 1688036858
Please file a bug at https://github.com/tarantool/tarantool/issues
Attempting backtrace... Note: since the server has already crashed, 
this may fail as well
#1  0x5600ebaf3ee2 in crash_collect+256
#2  0x5600ebaf491e in crash_signal_cb+100
#3  0x7feae5442520 in __sigaction+80
#4  0x5600eb870910 in iproto_on_shutdown_f(void*)+21
#5  0x5600ebb4e73c in trigger_commom_f+57
#6  0x5600ebb28844 in trigger_fiber_f(__va_list_tag*)+188
#7  0x5600eb85fc05 in fiber_cxx_invoke(int (*)(__va_list_tag*), __va_list_tag*)+34
#8  0x5600ebb00328 in fiber_loop+219
#9  0x5600ebe6c25a in coro_init+120

stack traceback:
```

Closes https://github.com/tarantool/luatest/issues/252