### PR TITLE
luatest: put grep_log function to utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Save server artifacts (logs, snapshots, etc.) if the test fails.
 - Group working directories of servers inside a replica set into one directory.
 - Fix collecting coverage if tarantool binary has a suffix.
+- Put `grep_log()` function to utils and expose it as a part of API.
 
 ## 0.5.7
 


### PR DESCRIPTION
Function grep_log() could be useful for searching string patterns even when Server instance is not possible. For example a case [1] when we need to start Tarantool instance with our own options.

Now for using grep_log one needs create an empty Server instance and then call grep_log() for it. It looks ugly:

```lua
local server = t.Server:new({})
local res = server:grep_log(msg, 1024, {filename = file})
```

Patch moves grep_log() to utils, this allows using grep_log() even Server instance is not used.

1. https://github.com/tarantool/tarantool/pull/8836

I didn't forget about

- [ ] Tests (not required, already covered)
- [x] Changelog
- [x] Documentation