### PR TITLE
coverage: support tarantool binary with a suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
   when a server fails to start due to bad configuration.
 - Save server artifacts (logs, snapshots, etc.) if the test fails.
 - Group working directories of servers inside a replica set into one directory.
+- Fix collecting coverage if tarantool binary has a suffix.
 
 ## 0.5.7
 

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -169,7 +169,7 @@ function Server:initialize()
             table.insert(self.args, 3, self.command)
             self.command = arg[-1]
         -- If command is tarantool, add `-l luatest.coverage`
-        elseif self.command:endswith('/tarantool') then
+        elseif utils.is_tarantool_binary(self.command) then
             if not fun.index('luatest.coverage', self.args) then
                 table.insert(self.args, 1, '-l')
                 table.insert(self.args, 2, 'luatest.coverage')
@@ -248,7 +248,7 @@ function Server:start(opts)
     local args = table.copy(self.args)
     local env = table.copy(os.environ())
 
-    if not command:endswith('/tarantool') then
+    if not utils.is_tarantool_binary(self.command) then
         -- When luatest is installed as a rock, the internal server_instance.lua
         -- script won't have execution permissions even though it has them in the
         -- source tree, and won't be able to be run while a server start. To bypass

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -182,4 +182,8 @@ function utils.version_ge(version1, version2)
     end
 end
 
+function utils.is_tarantool_binary(path)
+    return path:find('^.*/tarantool[^/]*$') ~= nil
+end
+
 return utils

--- a/test/utils_test.lua
+++ b/test/utils_test.lua
@@ -1,0 +1,24 @@
+local t = require('luatest')
+local g = t.group()
+
+local utils = require('luatest.utils')
+
+g.test_is_tarantool_binary = function()
+    local cases = {
+        {'/usr/bin/tarantool', true},
+        {'/usr/local/bin/tarantool', true},
+        {'/usr/local/bin/tt', false},
+        {'/usr/bin/ls', false},
+        {'/home/myname/app/bin/tarantool', true},
+        {'/home/tarantool/app/bin/go-server', false},
+        {'/usr/bin/tarantool-ee_gc64-2.11.0-0-r577', true},
+        {'/home/tarantool/app/bin/tarantool', true},
+        {'/home/tarantool/app/bin/tarantool-ee_gc64-2.11.0-0-r577', true},
+    }
+
+    for _, case in ipairs(cases) do
+        local path, result = unpack(case)
+        t.assert_equals(utils.is_tarantool_binary(path), result,
+                        ("Unexpected result for %q"):format(path))
+    end
+end


### PR DESCRIPTION
Fix collecting coverage if tarantool binary has a suffix. For example, binaries installed with `tt install` always have a suffix and non-suffix symlink for an active binary (luatest resolves symlinks while working with a command).

I didn't forget about

- [x] Tests
- [x] Changelog
- Documentation (internal?)

Closes #311