### PR TITLE
Do not raise error in `save_artifacts` function

### DIFF
--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -353,8 +353,8 @@ end
 function Server:save_artifacts()
     local ok, err = fio.copytree(self.workdir, self.artifacts)
     if not ok then
-        error(('Failed to copy artifacts for server (alias: %s, workdir: %s, pid: %d): %s')
-            :format(self.alias, fio.basename(self.workdir), self.process.pid, err))
+        log.error(('Failed to copy artifacts for server (alias: %s, workdir: %s): %s')
+            :format(self.alias, fio.basename(self.workdir), err))
     end
 end
 


### PR DESCRIPTION
The error has been replaced with a log entry (if the copying process failed, the current test will be marked as failed). Also, the PID of the server process was removed from the log string because the process may be missing.

Close #321