### PR TITLE
Not delete the server's working directory in `Server:drop()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Save server artifacts (logs, snapshots, etc.) if the test fails.
 - Group working directories of servers inside a replica set into one directory.
 - Fix collecting coverage if tarantool binary has a suffix.
+- Add `--no-clean` option to disable deletion of the var directory.
 
 ## 0.5.7
 

--- a/luatest/replica_set.lua
+++ b/luatest/replica_set.lua
@@ -183,12 +183,16 @@ function ReplicaSet:stop()
     end
 end
 
---- Stop all servers in the replica set and clean their working directories.
+--- Stop all servers in the replica set and save their artifacts if the test fails.
+-- This function should be used only at the end of the test (`after_test`,
+-- `after_each`, `after_all` hooks) to terminate all server processes in
+-- the replica set. Besides process termination, it saves the contents of
+-- each server working directory to the `<vardir>/artifacts` directory
+-- for further analysis if the test fails.
 function ReplicaSet:drop()
     for _, server in ipairs(self.servers) do
         server:drop()
     end
-    fio.rmtree(self.workdir)
 end
 
 --- Get a server which is a writable node in the replica set.

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -438,12 +438,15 @@ function Server:stop()
     end
 end
 
---- Stop the server and clean its working directory.
+--- Stop the server and save its artifacts if the test fails.
+-- This function should be used only at the end of the test (`after_test`,
+-- `after_each`, `after_all` hooks) to terminate the server process.
+-- Besides process termination, it saves the contents of the server
+-- working directory to the `<vardir>/artifacts` directory for further
+-- analysis if the test fails.
 function Server:drop()
     self:stop()
     self:save_artifacts()
-
-    fio.rmtree(self.workdir)
 
     self.instance_id = nil
     self.instance_uuid = nil

--- a/test/replica_set_test.lua
+++ b/test/replica_set_test.lua
@@ -89,24 +89,6 @@ g.test_save_rs_artifacts_when_server_workdir_passed = function()
 
 end
 
-g.before_test('test_remove_rs_artifacts_when_test_success', function()
-    g.rs:build_and_add_server({alias = 'replica1', box_cfg = g.box_cfg})
-    g.rs:build_and_add_server({alias = 'replica2', box_cfg = g.box_cfg})
-    g.rs:build_and_add_server({alias = 'replica3', box_cfg = g.box_cfg})
-    g.rs:start()
-
-    g.rs_artifacts = ('%s/artifacts/%s'):format(Server.vardir, g.rs.id)
-    g.s1_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica1').id)
-    g.s2_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica2').id)
-    g.s3_artifacts = ('%s/%s'):format(g.rs_artifacts, g.rs:get_server('replica3').id)
-end)
-
-g.test_remove_rs_artifacts_when_test_success = function()
-    g.rs:drop()
-
-    t.assert_equals(fio.path.exists(g.rs.workdir), false)
-end
-
 g.test_rs_no_socket_collision_with_custom_alias = function()
     local s1 = g.rs:build_server({alias = 'foo'})
     local s2 = g.rs:build_server({alias = 'bar'})

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -373,14 +373,6 @@ g.test_save_server_artifacts_when_test_failed = function()
     t.assert_equals(fio.path.is_dir(s2_artifacts), true)
 end
 
-g.test_remove_server_artifacts_when_test_success = function()
-    local s = Server:new()
-    s:start()
-    s:drop()
-
-    t.assert_equals(fio.path.exists(s.workdir), false)
-end
-
 g.test_server_build_listen_uri = function()
     local uri = Server.build_listen_uri('foo')
     t.assert_equals(uri, ('%s/foo.sock'):format(Server.vardir))


### PR DESCRIPTION
### Description

Now, luatest does not delete the server's working directory in the `Server:drop()` function. Instead of this, it deletes the whole var directory (default: `/tmp/t`) before running tests. So all server artifacts from all tests are saved after the run and can be analyzed.

However, you can disable this deletion by specifying the new `--no-clean` option.

### :green_circle: What's new in administration

- server artifacts are never deleted after the test run, so it takes some disk space;
- `--no-clean` - new option to disable deletion of the var directory before running tests.

#### Usage

```bash
$ ls /tmp/t
server-foo server-bar ...
$ ./bin/luatest -c -v ./test/new_test.lua
...
$ ls /tmp/t
server-new123
$ ./bin/luatest -c -v --no-clean ./test/new_test.lua
$ ls /tmp/t
server-new123 server-new456
```

Part of #308