### PR TITLE
Fix save artifacts

### DIFF
--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -338,6 +338,11 @@ function Runner.mt:update_status(node, err)
     elseif err.status == 'fail' or err.status == 'error' or err.status == 'skip'
         or err.status == 'xfail' or err.status == 'xsuccess' then
         node:update_status(err.status, err.message, err.trace)
+        if utils.table_len(node.servers) > 0 then
+            for _, server in pairs(node.servers) do
+                server:save_artifacts()
+            end
+        end
     else
         error('No such status: ' .. pp.tostring(err.status))
     end
@@ -458,13 +463,6 @@ end
 function Runner.mt:invoke_test_function(test)
     local err = self:protected_call(test.group, test.method, test.name)
     self:update_status(test, err)
-    if not test:is('success') then
-        if utils.table_len(test.servers) > 0 then
-            for _, server in pairs(test.servers) do
-                server:save_artifacts()
-            end
-        end
-    end
 end
 
 function Runner.mt:find_test(groups, name)


### PR DESCRIPTION
Since commit [^1] the `Server:save_artifacts()` function was called more than once. Due to this fact we could overwrite already saved artifacts. Added a flag that will ensure that the saving will be executed only once.

There was also a problem when copying artifacts was not performed but the path to the artifacts was formed as a directory with artifacts:

```
    artifacts:
        server -> /tmp/t/artifacts/server-XXX
```

And if we tried to look at these artifacts, we could see this:

```
    $ ls -la /tmp/t/artifacts/server-XXX
    ls: cannot access '/tmp/t/artifacts/server-XXX': No such file or
    directory
```

To show explicitly that the saving failed with an error, the following
string will now be written to the artifacts:

```
    artifacts:
        server -> Failed to copy artifacts for server (alias: server-XXX
        workdir: /tmp/t/artifacts/server-XXX)
```

[^1]: https://github.com/tarantool/luatest/commit/251b35f