### PR TITLE
Improved error message for one assert function

### DIFF
--- a/luatest/assertions.lua
+++ b/luatest/assertions.lua
@@ -472,7 +472,8 @@ local function _assert_error_msg_equals(stripFileAndLine, expectedMsg, func, ...
     end
     local differ = false
     if stripFileAndLine then
-        if error_msg:gsub("^.+:%d+: ", "") ~= expectedMsg then
+        error_msg = error_msg:gsub("^.+:%d+: ", "")
+        if error_msg ~= expectedMsg then
             differ = true
         end
     else

--- a/test/assertions_test.lua
+++ b/test/assertions_test.lua
@@ -62,3 +62,25 @@ g.test_assert_comparisons_error = function()
     helper.assert_failure_contains('must supply only number arguments.\n'..
     'Arguments supplied: \"one\", 3', t.assert_gt, 'one', 3)
 end
+
+local function external_error_fn(msg)
+    error(msg)
+end
+
+local g2 = t.group('g2', {
+    {fn = external_error_fn},
+    {fn = error},
+    {fn = function(msg) error(msg) end}
+})
+
+g2.test_assert_error_msg_content_equals = function(cg)
+    local msg = "error"
+    t.assert_error_msg_content_equals(msg, cg.params.fn, msg)
+    t.assert_error_msg_content_equals(msg, cg.params.fn, "foo.bar:1: " .. msg)
+    t.assert_error_msg_content_equals(msg, cg.params.fn, "foo.bar:123: " .. msg)
+    t.assert_error_msg_content_equals(msg, cg.params.fn, "/foo/bar.lua:1: " .. msg)
+    t.assert_error_msg_content_equals(msg, cg.params.fn, ".../foo/bar.lua:1: " .. msg)
+    t.assert_error_msg_content_equals(msg, cg.params.fn, "foo.bar:1: foo.bar:1: " .. msg)
+    t.assert_error_msg_content_equals(msg, cg.params.fn, "foo.bar:1: .../foo/bar.lua:1: " .. msg)
+    t.assert_error_msg_content_equals(msg, cg.params.fn, "foo.bar.bar:1: foo.bar.bar:1: " .. msg)
+end


### PR DESCRIPTION
### What's the problem?

If the user makes a mistake in the `assert_error_msg_content_equals`:

    t.assert_error_msg_content_equals("bad", error, "foo:1: bar")

where:
```
    "bad" - excepted error message
    error - built-in function (there may be another function here)
    "foo:1: bar" - argument for the function
```

then the following error will be returned:

    Error message expected: "bad"
    Error message received: "foo:1: bar"

The user thinks that a comparison is being made between `foo:1: bar` and `bad`. He notices this error and at the same time can write the following:

    t.assert_error_msg_content_equals("foo:1: bar", error, "foo:1: bar")

Now he will get the following error:

    Error message expected: "foo:1: bar"
    Error message received: "foo:1: bar"

It seems that the function doesn't work cause these strings are equal. In fact, a comparison will be performed between `foo:1: bar` (excepted) and `bar` strings (because `foo:1: ` will be dropped from the error message by regex).

The next use of the function will be correct:

    t.assert_error_msg_content_equals("bar", error, "foo:1: bar")

### What's the solution?

It is necessary to save the result of conversion after the `gsub`. So this way the user will see the actual strings that are being compared:

    t.assert_error_msg_content_equals("bad", error, "foo:1: bar")
    Error message expected: "bad"
    Error message received: "bar"

Close #316
