### PR TITLE
Fix running unit tests with coverage enabled

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -32,5 +32,5 @@ jobs:
       - name: Run linter
         run: make -C build lint
 
-      - name: Run tests
-        run: bin/luatest -v --shuffle group
+      - name: Run tests with coverage
+        run: make -C build selftest-coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,14 +69,14 @@ add_custom_target(lint
 )
 add_custom_target(selftest
   DEPENDS bootstrap
-  COMMAND bin/luatest --shuffle group
+  COMMAND bin/luatest -v --shuffle group
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )
 
-add_custom_target(test_with_coverage_report
+add_custom_target(selftest-coverage
   DEPENDS bootstrap
   COMMAND rm -f tmp/luacov.*.out*
-  COMMAND tarantool -l luatest.coverage bin/luatest
+  COMMAND tarantool -l luatest.coverage bin/luatest -v --shuffle group
   COMMAND .rocks/bin/luacov .
   COMMAND echo
   COMMAND grep -A999 '^Summary' tmp/luacov.report.out


### PR DESCRIPTION
Before this patch, it was impossible to run luatest unit tests with the coverage enabled because some tests failed with the following error:

    luatest/test/server_test.lua:393: net_box is not connected
    stack traceback:
        ...
        [C]: in function 'xpcall'
    artifacts:
        server -> /tmp/t/artifacts/server-KLiHQDTbAJ4b
        server -> /tmp/t/artifacts/server-QQQzEqDr4Hsy

This patch fixes the issue.

Also, it updates the name of the `make` target for running unit tests with coverage to `selftest-coverage` and enables coverage testing on CI.