### PR TITLE
Accept table as net_box_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
   * Fixed incorrent unix socket path length check (gh-341).
+  * Now net_box_uri can be accepted as table (gh-342).
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+  * Fixed incorrent unix socket path length check (gh-341).
+
 ## 1.0.0
 
 - Extend `server.lua` API:

--- a/luatest/replica_proxy.lua
+++ b/luatest/replica_proxy.lua
@@ -31,8 +31,7 @@ function Proxy:inherit(object)
 end
 
 local function check_tarantool_version()
-    local version = utils.get_tarantool_version()
-    if utils.version_ge(version, utils.version(2, 10, 1)) then
+    if utils.version_current_ge_than(2, 10, 1) then
         return
     else
         error('Proxy requires Tarantool 2.10.1 and newer')

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -156,12 +156,13 @@ function Server:initialize()
             self.net_box_uri = 'localhost:' .. self.net_box_port
         end
     end
-    if uri.parse(self.net_box_uri).host == 'unix/' then
+    local parsed_net_box_uri = uri.parse(self.net_box_uri)
+    if parsed_net_box_uri.host == 'unix/' then
         -- Linux uses max 108 bytes for Unix domain socket paths, which means a 107 characters
         -- string ended by a null terminator. Other systems use 104 bytes and 103 characters strings.
         local max_unix_socket_path = {linux = 107, other = 103}
         local system = os.execute('[ $(uname) = Linux ]') == 0 and 'linux' or 'other'
-        if self.net_box_uri:len() > max_unix_socket_path[system] then
+        if parsed_net_box_uri.unix:len() > max_unix_socket_path[system] then
             error(('Net box URI must be <= max Unix domain socket path length (%d chars)')
                 :format(max_unix_socket_path[system]))
         end

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -41,7 +41,7 @@ local Server = {
 
         http_port = '?number',
         net_box_port = '?number',
-        net_box_uri = '?string',
+        net_box_uri = '?string|table',
         net_box_credentials = '?table',
 
         alias = '?string',
@@ -166,6 +166,9 @@ function Server:initialize()
             error(('Net box URI must be <= max Unix domain socket path length (%d chars)')
                 :format(max_unix_socket_path[system]))
         end
+    end
+    if type(self.net_box_uri) == 'table' then
+        self.net_box_uri = uri.format(parsed_net_box_uri, true)
     end
 
     self.env = utils.merge(self.env or {}, self:build_env())
@@ -358,7 +361,7 @@ function Server:restart(params, opts)
 
         http_port = '?number',
         net_box_port = '?number',
-        net_box_uri = '?string',
+        net_box_uri = '?string|table',
         net_box_credentials = '?table',
 
         alias = '?string',

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -182,6 +182,11 @@ function utils.version_ge(version1, version2)
     end
 end
 
+function utils.version_current_ge_than(major, minor, patch)
+    return utils.version_ge(utils.get_tarantool_version(),
+                            utils.version(major, minor, patch))
+end
+
 function utils.is_tarantool_binary(path)
     return path:find('^.*/tarantool[^/]*$') ~= nil
 end

--- a/test/proxy_test.lua
+++ b/test/proxy_test.lua
@@ -9,8 +9,7 @@ local fiber = require('fiber')
 local g = t.group('proxy-version-check')
 
 g.test_proxy_errors = function()
-    t.skip_if(utils.version_ge(utils.get_tarantool_version(),
-                               utils.version(2, 10, 1)),
+    t.skip_if(utils.version_current_ge_than(2, 10, 1),
               "Proxy works on Tarantool 2.10.1+, nothing to test")
     t.assert_error_msg_contains('Proxy requires Tarantool 2.10.1 and newer',
                                 proxy.new, proxy, {
@@ -26,8 +25,7 @@ local g1 = t.group('proxy', {
 
 g1.before_all(function(cg)
     -- Proxy only works on tarantool 2.10+
-    t.run_only_if(utils.version_ge(utils.get_tarantool_version(),
-                                   utils.version(2, 10, 1)),
+    t.run_only_if(utils.version_current_ge_than(2, 10, 1),
                   [[Proxy works on Tarantool 2.10.1+.
                     See tarantool/tarantool@57ecb6cd90b4 for details]])
     cg.rs = replica_set:new{}


### PR DESCRIPTION
Prior to this patch-set, box.cfg.listen was only set to string or number. Because of this, it was not possible to use the table as net_box_uri when creating the server. This patch-set allows the table to be used as net_box_uri. Also, now length of unix socket path is checked instead of length of whole URI. However, to support backward compatibility, the table representation of net_box_uri is converted to string.

Closes #341
Closes #342