### PR TITLE
server: change error message for unix socket path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `assert_error_covers`.
 - Add more logs (gh-326).
 - Add `justrun` helper as a tarantool runner and output catcher (gh-365).
+- Changed error message for too long Unix domain socket paths (gh-341).
 
 ## 1.0.1
 

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -164,8 +164,9 @@ function Server:initialize()
         local max_unix_socket_path = {linux = 107, other = 103}
         local system = os.execute('[ $(uname) = Linux ]') == 0 and 'linux' or 'other'
         if parsed_net_box_uri.unix:len() > max_unix_socket_path[system] then
-            error(('Net box URI must be <= max Unix domain socket path length (%d chars)')
-                :format(max_unix_socket_path[system]))
+            error(('Unix domain socket path cannot be longer than %d chars. ' ..
+                   'Current path is: %s'):format(max_unix_socket_path[system],
+                                                 parsed_net_box_uri.unix))
         end
     end
     if type(self.net_box_uri) == 'table' then

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -286,8 +286,8 @@ g.test_max_unix_socket_path_exceeded = function()
 
     t.assert_equals(string.len(net_box_uri), max_unix_socket_path[system] + 1)
     t.assert_error_msg_contains(
-        string.format('Net box URI must be <= max Unix domain socket path length (%s chars)',
-            max_unix_socket_path[system]),
+        string.format('Unix domain socket path cannot be longer than %d ' ..
+                      'chars. Current path is:', max_unix_socket_path[system]),
         Server.new, Server, {
             command = command,
             workdir = workdir,


### PR DESCRIPTION
This patch changes the error message when the Unix socket path length exceeds a certain limit.

Follow-up #341
