### PR TITLE
Add syntax sugar for more convenient logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Fixed incorrent unix socket path length check (gh-341).
   * Now net_box_uri can be accepted as table (gh-342).
   * Fixed returning values from `Server:exec()` if some of them are nil (gh-350).
+  * Introduce `luatest.log` helper (gh-326).
 
 ## 1.0.0
 

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -33,6 +33,11 @@ luatest.ReplicaSet = require('luatest.replica_set')
 local Group = require('luatest.group')
 local hooks = require('luatest.hooks')
 local parametrizer = require('luatest.parametrizer')
+local utils = require('luatest.utils')
+
+--- Add syntax sugar for logging.
+--
+luatest.log = utils.log
 
 --- Add before suite hook.
 --

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -1,6 +1,9 @@
 local digest = require('digest')
 local fun = require('fun')
 local yaml = require('yaml')
+local log = require('log')
+
+local pp = require('luatest.pp')
 
 local utils = {}
 
@@ -189,6 +192,14 @@ end
 
 function utils.is_tarantool_binary(path)
     return path:find('^.*/tarantool[^/]*$') ~= nil
+end
+
+function utils.log(msg, ...)
+    local args = {...}
+    for k, v in pairs(args) do
+        args[k] = pp.tostringlog(v)
+    end
+    log.info(msg, unpack(args))
 end
 
 return utils


### PR DESCRIPTION
You can use `luatest.log` for logging. This is convenient in case of debugging in several places at the same time:

```lua
    local luatest = require('luatest')
    
    luatest.log('outside')
    g.test_foo = function()
        luatest.log('inside')
        g.server:exec(function() luatest.log('hi!') end)
    end

    I> outside
    I> inside
    I> hi!
```

The pretty conversion of arguments of any type will be performed automatically:
```lua
    luatest.log('My structure is %s', {a = 1, b = 2, c = {cc = 1}})
    I> My structure is {a = 1, b = 2, c = {cc = 1}}
```

Closes #326
