### PR TITLE
Improve log submodule of luatest

### DIFF
--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -33,11 +33,10 @@ luatest.ReplicaSet = require('luatest.replica_set')
 local Group = require('luatest.group')
 local hooks = require('luatest.hooks')
 local parametrizer = require('luatest.parametrizer')
-local utils = require('luatest.utils')
 
 --- Add syntax sugar for logging.
 --
-luatest.log = utils.log
+luatest.log = require('luatest.log')
 
 --- Add before suite hook.
 --

--- a/luatest/log.lua
+++ b/luatest/log.lua
@@ -1,0 +1,50 @@
+local tarantool_log = require('log')
+
+local utils = require('luatest.utils')
+local pp = require('luatest.pp')
+
+-- Utils for logging
+local log = {}
+local default_level = 'info'
+
+local function _log(level, msg, ...)
+    if not utils.version_current_ge_than(2, 5, 1) then
+        return
+    end
+    local args = {...}
+    for k, v in pairs(args) do
+        args[k] = pp.tostringlog(v)
+    end
+    return tarantool_log[level](msg, unpack(args))
+end
+
+--- Extra wrapper for `__call` function
+-- An additional function that takes `table` as
+-- the first argument to call table function.
+local function _log_default(t, msg, ...)
+    return t[default_level](msg, ...)
+end
+
+function log.info(msg, ...)
+    return _log('info', msg, ...)
+end
+
+function log.verbose(msg, ...)
+    return _log('verbose', msg, ...)
+end
+
+function log.debug(msg, ...)
+    return _log('debug', msg, ...)
+end
+
+function log.warn(msg, ...)
+    return _log('warn', msg, ...)
+end
+
+function log.error(msg, ...)
+    return _log('error', msg, ...)
+end
+
+setmetatable(log, {__call = _log_default})
+
+return log

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -1,9 +1,6 @@
 local digest = require('digest')
 local fun = require('fun')
 local yaml = require('yaml')
-local log = require('log')
-
-local pp = require('luatest.pp')
 
 local utils = {}
 
@@ -192,14 +189,6 @@ end
 
 function utils.is_tarantool_binary(path)
     return path:find('^.*/tarantool[^/]*$') ~= nil
-end
-
-function utils.log(msg, ...)
-    local args = {...}
-    for k, v in pairs(args) do
-        args[k] = pp.tostringlog(v)
-    end
-    log.info(msg, unpack(args))
 end
 
 return utils


### PR DESCRIPTION
We improved `luatest.log` module for convenient logging and refactored it:

    local t = require('luatest')
    t.log('Info log: %s', 'foo')
    t.log.warn('Warn log from %s', 'foo')

The following functions of the `luatest.log` module are presented:

    t.log.error(msg[, args])
    t.log.warn(msg[, args])
    t.log.info(msg[, args])
    t.log.verbose(msg[, args])
    t.log.debug(msg[, args])

    t.log() - syntax sugar for t.log.info(...)

Follows #326
