### PR TITLE
Add memory leak detection during server process execution 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add logging to unified file (gh-324).
+- Add memory leak detection during server process execution (gh-349).
 
 ## 1.0.1
 

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -459,6 +459,17 @@ function Server:stop()
                 )
             )
         end
+        if self.process.output_beautifier.stderr:find('LeakSanitizer') then
+            error(
+                ('Memory leak during process execution (alias: %s, workdir: %s, pid: %s)\n%s')
+                :format(
+                    self.alias,
+                    fio.basename(self.workdir),
+                    self.process.pid,
+                    self.process.output_beautifier.stderr
+                )
+            )
+        end
         log.debug('Killed server process PID ' .. self.process.pid)
         self.process = nil
     end


### PR DESCRIPTION
Memory leak detection may occur when working with the server:

```lua 
g.test_foo = function()
    ...
    g.server:exec(function()
        -- there is an error from LeakSanitizer in `stderr` here
    end)
    g.server:exec(function()
        -- server is alive
   end)
   t.assert(true)
end)

g.after_all(function()
    g.server:drop() -- `test_foo` has passed
end)
```

We have added a check for the `LeakSanitizer` substring in `stderr` of the server process. If it's found, an error will be thrown and test will fail.

Closes https://github.com/tarantool/luatest/issues/349

ℹ️ P.S. Although this PR solves the problem described in #349, there may be a more elegant solution to such detections. It is described in more detail in #358 