### PR TITLE
Improve `luatest.log` function if a `nil` value is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add logging to unified file (gh-324).
 - Add memory leak detection during server process execution (gh-349).
+- Improve `luatest.log` function if a `nil` value is passed (gh-360).
 
 ## 1.0.1
 

--- a/luatest/log.lua
+++ b/luatest/log.lua
@@ -11,9 +11,10 @@ local function _log(level, msg, ...)
     if not utils.version_current_ge_than(2, 5, 1) then
         return
     end
-    local args = {...}
-    for k, v in pairs(args) do
-        args[k] = pp.tostringlog(v)
+    local args = {}
+    for i = 1, select('#', ...) do
+        local v = select(i, ...)
+        table.insert(args, pp.tostringlog(v))
     end
     return tarantool_log[level](msg, unpack(args))
 end


### PR DESCRIPTION
Use `select()` to avoid `bad argument #3 to '?' (no value)` error in following example:
```lua
    luatest.log('%s and %s', cdata<void *>: NULL, nil)
```
Closes #360