### PR TITLE
Migrate `treegen` module and adapt it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add `cbuilder` helper as a declarative configuration builder (gh-366).
 - Make `assert_error_*` additionally check error trace if required.
 - Add `--list-test-cases` and `--run-test-case` CLI options.
+- Introduce preloaded hooks (gh-380).
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Make `assert_error_*` additionally check error trace if required.
 - Add `--list-test-cases` and `--run-test-case` CLI options.
 - Introduce preloaded hooks (gh-380).
+- Add `treegen` helper as a tree generator (gh-364).
 
 ## 1.0.1
 

--- a/README.rst
+++ b/README.rst
@@ -165,14 +165,14 @@ Preloaded hooks extend base hooks. They behave like the pytest fixture with the 
     -- my_helper.lua
     local hooks = require('luatest.hooks')
 
-    hooks.before_all_preloaded(function() print('start foo') end)
-    hooks.after_all_preloaded(function() print('stop foo') end)
+    hooks.before_suite_preloaded(function() print('start foo') end)
+    hooks.after_suite_preloaded(function() print('stop foo') end)
 
-    hooks.before_each_preloaded(function() print('start bar') end)
-    hooks.after_each_preloaded(function() print('stop bar') end)
+    hooks.before_all_preloaded(function() print('start bar') end)
+    hooks.after_all_preloaded(function() print('stop bar') end)
 
-    hooks.before_all_preloaded(function() print('start baz') end)
-    hooks.after_all_preloaded(function() print('stop baz') end)
+    hooks.before_each_preloaded(function() print('start baz') end)
+    hooks.after_each_preloaded(function() print('stop baz') end)
 
 If you run the following test:
 
@@ -190,13 +190,13 @@ Then the hooks are executed in the following sequence:
 
 .. code-block:: text
     |\ start foo
-    | \ start baz
+    | \ start bar
     |  \ prepare
-    |   \ start bar
+    |   \ start baz
     |      test_print (everythings is ok)
-    |   / stop bar
+    |   / stop baz
     |  / cleanup
-    | / stop baz
+    | / stop bar
     |/ stop foo
 
 ---------------------------------

--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,48 @@ To change default order use:
     local t = require('luatest')
     t.configure({shuffle = 'group'})
 
+---------------------------------
+Preloaded hooks
+---------------------------------
+Preloaded hooks extend base hooks. They behave like the pytest fixture with the ``autouse`` parameter.
+
+.. code-block:: lua
+    -- my_helper.lua
+    local hooks = require('luatest.hooks')
+
+    hooks.before_all_preloaded(function() print('start foo') end)
+    hooks.after_all_preloaded(function() print('stop foo') end)
+
+    hooks.before_each_preloaded(function() print('start bar') end)
+    hooks.after_each_preloaded(function() print('stop bar') end)
+
+    hooks.before_all_preloaded(function() print('start baz') end)
+    hooks.after_all_preloaded(function() print('stop baz') end)
+
+If you run the following test:
+
+.. code-block:: lua
+    local t = require('luatest')
+    local my_helper = require('my_helper')
+    local g = t.group()
+
+    g.before_all(function() print('prepare') end)
+    g.after_all(function() print('cleanup') end)
+
+    g.test_print = function() print('everythings is ok') end
+
+Then the hooks are executed in the following sequence:
+
+.. code-block:: text
+    |\ start foo
+    | \ start baz
+    |  \ prepare
+    |   \ start bar
+    |      test_print (everythings is ok)
+    |   / stop bar
+    |  / cleanup
+    | / stop baz
+    |/ stop foo
 
 ---------------------------------
 List of luatest functions

--- a/config.ld
+++ b/config.ld
@@ -8,7 +8,8 @@ file = {
     'luatest/server.lua',
     'luatest/replica_set.lua',
     'luatest/justrun.lua',
-    'luatest/cbuilder.lua'
+    'luatest/cbuilder.lua',
+    'luatest/hooks.lua'
 }
 topics = {
     'CHANGELOG.md',

--- a/config.ld
+++ b/config.ld
@@ -9,7 +9,8 @@ file = {
     'luatest/replica_set.lua',
     'luatest/justrun.lua',
     'luatest/cbuilder.lua',
-    'luatest/hooks.lua'
+    'luatest/hooks.lua',
+    'luatest/treegen.lua'
 }
 topics = {
     'CHANGELOG.md',

--- a/luatest/group.lua
+++ b/luatest/group.lua
@@ -61,7 +61,7 @@ function Group.mt:initialize(name)
         error('Group name must not contain `/`: ' .. name)
     end
     self.name = name
-    hooks.define_group_hooks(self)
+    hooks._define_group_hooks(self)
 end
 
 return Group

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -57,7 +57,12 @@ luatest.cbuilder = require('luatest.cbuilder')
 --
 -- @function after_suite
 -- @func fn
-hooks.define_suite_hooks(luatest)
+hooks._define_suite_hooks(luatest)
+
+--- Add extra hooks methods.
+--
+-- @see luatest.hooks
+luatest.hooks = hooks
 
 luatest.groups = {}
 

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -599,7 +599,7 @@ function Runner.mt:all_test_names()
     return result
 end
 
-hooks.patch_runner(Runner)
+hooks._patch_runner(Runner)
 capturing(Runner)
 
 return Runner

--- a/luatest/treegen.lua
+++ b/luatest/treegen.lua
@@ -1,0 +1,212 @@
+--- Working tree generator.
+--
+-- Generates a tree of Lua files using provided templates and
+-- filenames.
+--
+-- @usage
+--
+-- local t = require('luatest')
+-- local treegen = require('luatest.treegen')
+--
+-- local g = t.group()
+--
+-- g.test_foo = function(g)
+--     treegen.add_template('^.*$', 'test_script')
+--     local dir = treegen.prepare_directory({'foo/bar.lua', 'main.lua'})
+--     ...
+-- end
+--
+-- @module luatest.treegen
+
+local hooks = require('luatest.hooks')
+
+local fio = require('fio')
+local fun = require('fun')
+local checks = require('checks')
+
+local log = require('luatest.log')
+
+local treegen = {
+    _group = {}
+}
+
+local function find_template(group, script)
+    for position, template_def in ipairs(group._treegen.templates) do
+        if script:match(template_def.pattern) then
+            return position, template_def.template
+        end
+    end
+    error(("treegen: can't find a template for script %q"):format(script))
+end
+
+--- Write provided content into the given directory.
+--
+-- @string directory Directory where the content will be created.
+-- @string filename File to write (possible nested path: /foo/bar/main.lua).
+-- @string content The body to write.
+-- @return string
+function treegen.write_file(directory, filename, content)
+    checks('string', 'string', 'string')
+    local content_abspath = fio.pathjoin(directory, filename)
+    local flags = {'O_CREAT', 'O_WRONLY', 'O_TRUNC'}
+    local mode = tonumber('644', 8)
+
+    local contentdir_abspath = fio.dirname(content_abspath)
+    log.info('Creating a directory: %s', contentdir_abspath)
+    fio.mktree(contentdir_abspath)
+
+    log.info('Writing a content: %s', content_abspath)
+    local fh = fio.open(content_abspath, flags, mode)
+    fh:write(content)
+    fh:close()
+    return content_abspath
+end
+
+-- Generate a content that follows a template and write it at the
+-- given path in the given directory.
+--
+-- @table group Group of tests.
+-- @string directory Directory where the content will be created.
+-- @string filename File to write (possible nested path: /foo/bar/main.lua).
+-- @table replacements List of replacement templates.
+-- @return string
+local function gen_content(group, directory, filename, replacements)
+    checks('table', 'string', 'string', 'table')
+    local _, template = find_template(group, filename)
+    replacements = fun.chain({filename = filename}, replacements):tomap()
+    local body = template:gsub('<(.-)>', replacements)
+    return treegen.write_file(directory, filename, body)
+end
+
+--- Initialize treegen module in the given group of tests.
+--
+-- @tab group Group of tests.
+local function init(group)
+    checks('table')
+    group._treegen = {
+        tempdirs = {},
+        templates = {}
+    }
+    treegen._group = group
+end
+
+--- Remove all temporary directories created by the test
+-- unless KEEP_DATA environment variable is set to a
+-- non-empty value.
+local function clean()
+    if treegen._group._treegen == nil then
+        return
+    end
+
+    local dirs = table.copy(treegen._group._treegen.tempdirs) or {}
+    treegen._group._treegen.tempdirs = nil
+
+    local keep_data = (os.getenv('KEEP_DATA') or '') ~= ''
+
+    for _, dir in ipairs(dirs) do
+        if keep_data then
+            log.info('Left intact due to KEEP_DATA env var: %s', dir)
+        else
+            log.info('Recursively removing: %s', dir)
+            fio.rmtree(dir)
+        end
+    end
+
+    treegen._group._treegen.templates = nil
+end
+
+--- Save the template with the given pattern.
+--
+-- @string pattern File name template
+-- @string template A content template for creating a file.
+function treegen.add_template(pattern, template)
+    checks('string', 'string')
+    table.insert(treegen._group._treegen.templates, {
+        pattern = pattern,
+        template = template,
+    })
+end
+
+--- Remove the template by pattern.
+--
+-- @string pattern File name template
+function treegen.remove_template(pattern)
+    checks('string')
+    local is_found, position, _ = pcall(find_template, treegen._group, pattern)
+    if is_found then
+        table.remove(treegen._group._treegen.templates, position)
+    end
+end
+
+--- Create a temporary directory with given contents.
+--
+-- The contents are generated using templates added by
+-- treegen.add_template().
+--
+-- @usage
+--
+-- Example for {'foo/bar.lua', 'baz.lua'}:
+--
+-- /
+-- + tmp/
+--   + rfbWOJ/
+--     + foo/
+--     | + bar.lua
+--     + baz.lua
+--
+-- The return value is '/tmp/rfbWOJ' for this example.
+--
+-- @tab contents List of bodies of the content to write.
+-- @tab[opt] replacements List of replacement templates.
+-- @return string
+function treegen.prepare_directory(contents, replacements)
+    checks('?table', '?table')
+    replacements = replacements or {}
+
+    local dir = fio.tempdir()
+
+    -- fio.tempdir() follows the TMPDIR environment variable.
+    -- If it ends with a slash, the return value contains a double
+    -- slash in the middle: for example, if TMPDIR=/tmp/, the
+    -- result is like `/tmp//rfbWOJ`.
+    --
+    -- It looks harmless on the first glance, but this directory
+    -- path may be used later to form an URI for a Unix domain
+    -- socket. As result the URI looks like
+    -- `unix/:/tmp//rfbWOJ/instance-001.iproto`.
+    --
+    -- It confuses net_box.connect(): it reports EAI_NONAME error
+    -- from getaddrinfo().
+    --
+    -- It seems, the reason is a peculiar of the URI parsing:
+    --
+    -- tarantool> uri.parse('unix/:/foo/bar.iproto')
+    -- ---
+    -- - host: unix/
+    --   service: /foo/bar.iproto
+    --   unix: /foo/bar.iproto
+    -- ...
+    --
+    -- tarantool> uri.parse('unix/:/foo//bar.iproto')
+    -- ---
+    -- - host: unix
+    --   path: /foo//bar.iproto
+    -- ...
+    --
+    -- Let's normalize the path using fio.abspath(), which
+    -- eliminates the double slashes.
+    dir = fio.abspath(dir)
+
+    table.insert(treegen._group._treegen.tempdirs, dir)
+
+    for _, content in ipairs(contents) do
+        gen_content(treegen._group, dir, content, replacements)
+    end
+
+    return dir
+end
+
+hooks.before_all_preloaded(init)
+hooks.after_all_preloaded(clean)
+
+return treegen

--- a/test/hooks_test.lua
+++ b/test/hooks_test.lua
@@ -62,6 +62,73 @@ g.test_hooks = function()
     t.assert_equals(hooks, expected)
 end
 
+g.test_predefined_hooks = function()
+    local _hooks = require('luatest.hooks')
+    local hooks = {}
+
+    _hooks.before_suite_preloaded(function() table.insert(hooks, 'before_suite') end)
+    _hooks.after_suite_preloaded(function() table.insert(hooks, 'after_suite') end)
+    _hooks.before_suite_preloaded(function() table.insert(hooks, 'before_suite2') end)
+    _hooks.after_suite_preloaded(function() table.insert(hooks, 'after_suite2') end)
+
+    _hooks.before_all_preloaded(function() table.insert(hooks, 'before_all') end)
+    _hooks.after_all_preloaded(function() table.insert(hooks, 'after_all') end)
+    _hooks.before_all_preloaded(function() table.insert(hooks, 'before_all2') end)
+    _hooks.after_all_preloaded(function() table.insert(hooks, 'after_all2') end)
+
+    _hooks.before_each_preloaded(function() table.insert(hooks, 'before_each') end)
+    _hooks.after_each_preloaded(function() table.insert(hooks, 'after_each') end)
+    _hooks.before_each_preloaded(function() table.insert(hooks, 'before_each2') end)
+    _hooks.after_each_preloaded(function() table.insert(hooks, 'after_each2') end)
+
+    _hooks.before_suite_preloaded(function() table.insert(hooks, 'before_suite3') end)
+    _hooks.before_all_preloaded(function() table.insert(hooks, 'before_all3') end)
+    _hooks.before_all_preloaded(function() table.insert(hooks, 'before_all4') end)
+    _hooks.after_suite_preloaded(function() table.insert(hooks, 'after_suite3') end)
+    _hooks.after_all_preloaded(function() table.insert(hooks, 'after_all3') end)
+    _hooks.after_all_preloaded(function() table.insert(hooks, 'after_all4') end)
+
+    local result = helper.run_suite(function(lu2)
+        local t2 = lu2.group('test')
+        t2.before_all(function() table.insert(hooks, 'before_all_inner') end)
+        lu2.before_suite(function() table.insert(hooks, 'before_suite_inner') end)
+        lu2.after_suite(function() table.insert(hooks, 'after_suite_inner') end)
+        t2.after_all(function() table.insert(hooks, 'after_all_inner') end)
+        t2.before_each(function() table.insert(hooks, 'before_each_inner') end)
+        t2.after_each(function() table.insert(hooks, 'after_each_inner') end)
+        t2.test = function() table.insert(hooks, 'test') end
+    end)
+
+    t.assert_equals(result, 0)
+    t.assert_equals(hooks, {
+        "before_suite",
+        "before_suite2",
+        "before_suite3",
+        "before_suite_inner",
+        "before_all",
+        "before_all2",
+        "before_all3",
+        "before_all4",
+        "before_all_inner",
+        "before_each",
+        "before_each2",
+        "before_each_inner",
+        "test",
+        "after_each_inner",
+        "after_each2",
+        "after_each",
+        "after_all_inner",
+        "after_all4",
+        "after_all3",
+        "after_all2",
+        "after_all",
+        "after_suite_inner",
+        "after_suite3",
+        "after_suite2",
+        "after_suite",
+    })
+end
+
 g.test_hooks_legacy = function()
     local hooks = {}
     local expected = {}

--- a/test/treegen_test.lua
+++ b/test/treegen_test.lua
@@ -1,0 +1,48 @@
+local t = require('luatest')
+local fio = require('fio')
+
+local treegen = require('luatest.treegen')
+
+local g = t.group()
+
+
+local function assert_file_content_equals(file, expected)
+    local fh = fio.open(file)
+    t.assert_equals(fh:read(), expected)
+end
+
+g.test_prepare_directory = function()
+    treegen.add_template('^.*$', 'test_script')
+    local dir = treegen.prepare_directory({'foo/bar.lua', 'baz.lua'})
+
+    t.assert(fio.path.is_dir(dir))
+    t.assert(fio.path.exists(dir))
+
+    t.assert(fio.path.exists(fio.pathjoin(dir, 'foo', 'bar.lua')))
+    t.assert(fio.path.exists(fio.pathjoin(dir, 'baz.lua')))
+
+    assert_file_content_equals(fio.pathjoin(dir, 'foo', 'bar.lua'), 'test_script')
+    assert_file_content_equals(fio.pathjoin(dir, 'baz.lua'), 'test_script')
+end
+
+g.before_test('test_clean_keep_data', function()
+    treegen.add_template('^.*$', 'test_script')
+
+    os.setenv('KEEP_DATA', 'true')
+
+    g.dir = treegen.prepare_directory(g, {'foo.lua'})
+
+    t.assert(fio.path.is_dir(g.dir))
+    t.assert(fio.path.exists(g.dir))
+end)
+
+g.test_clean_keep_data = function()
+    t.assert(fio.path.is_dir(g.dir))
+    t.assert(fio.path.exists(g.dir))
+end
+
+g.after_test('test_clean_keep_data', function()
+    os.setenv('KEEP_DATA', '')
+    t.assert(fio.path.is_dir(g.dir))
+    t.assert(fio.path.exists(g.dir))
+end)


### PR DESCRIPTION
#### Introduce preloaded hooks

Preloaded hooks extend base hooks. They behave like the pytest fixture with the `autouse` parameter. This is useful when writing a module and using it with "auto" before/after hooks.

The following functions have been "preloaded" into `hooks.lua` module:
  - before_suite_preloaded(func)
  - after_suite_preloaded(func)
  - before_all_preloaded(func)
  - after_all_preloaded(func)
  - before_each_preloaded(func)
  - after_each_preloaded(func)

Closes #380

#### Migrate treegen module and adapt it

The original `treegen` module (path: tarantool/test/treegen.lua) has been moved to the current project with the following changes:

- refactoring;
- updated documentation.

Closes #364