### PR TITLE
Add trace check for error assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `justrun` helper as a tarantool runner and output catcher (gh-365).
 - Changed error message for too long Unix domain socket paths (gh-341).
 - Add `cbuilder` helper as a declarative configuration builder (gh-366).
+- Make `assert_error_*` additionally check error trace if required.
 
 ## 1.0.1
 

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -191,4 +191,9 @@ function utils.is_tarantool_binary(path)
     return path:find('^.*/tarantool[^/]*$') ~= nil
 end
 
+-- Return args as table with 'n' set to args number.
+function utils.table_pack(...)
+    return {n = select('#', ...), ...}
+end
+
 return utils

--- a/test/utils_test.lua
+++ b/test/utils_test.lua
@@ -22,3 +22,11 @@ g.test_is_tarantool_binary = function()
                         ("Unexpected result for %q"):format(path))
     end
 end
+
+g.test_table_pack = function()
+    t.assert_equals(utils.table_pack(), {n = 0})
+    t.assert_equals(utils.table_pack(1), {n = 1, 1})
+    t.assert_equals(utils.table_pack(1, 2), {n = 2, 1, 2})
+    t.assert_equals(utils.table_pack(1, 2, nil), {n = 3, 1, 2})
+    t.assert_equals(utils.table_pack(1, 2, nil, 3), {n = 4, 1, 2, nil, 3})
+end


### PR DESCRIPTION
In the scope of the referenced Tarantool issue we are going to change error trace of API to point to the caller place. The error should be `box.error` and the trace will be changed for `schema.lua` API at the beginning (fix all API at once is difficult).

We are going to use existing tests to test the change. In particular in case of Luatest let's check trace in `assert_error*` assertions besides the main assertion.

Required for https://github.com/tarantool/tarantool/issues/9914

See luatest bump in https://github.com/tarantool/test-run/pull/428
