### PR TITLE
Add --list-test-cases and --run-test-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed error message for too long Unix domain socket paths (gh-341).
 - Add `cbuilder` helper as a declarative configuration builder (gh-366).
 - Make `assert_error_*` additionally check error trace if required.
+- Add `--list-test-cases` and `--run-test-case` CLI options.
 
 ## 1.0.1
 

--- a/test/luaunit/utility_test.lua
+++ b/test/luaunit/utility_test.lua
@@ -610,6 +610,12 @@ function g.test_parse_cmd_line()
         output_file_name='toto.xml',
     })
 
+    -- list-test-cases
+    assert_subject({'--list-test-cases'}, {list_test_cases = true})
+
+    -- run-test-case
+    assert_subject({'--run-test-case', 'foo'}, {run_test_case = 'foo'})
+
     t.assert_error_msg_contains('option: -$', subject, {'-$',})
 end
 
@@ -708,6 +714,21 @@ function g.test_filter_tests()
     included, excluded = subject(testset, {'foo', 'bar', '!t.t.', '%.bar'})
     t.assert_equals(included, {testset[2], testset[4], testset[6], testset[7], testset[8]})
     t.assert_equals(#excluded, 3)
+
+    -- --run-test-case without patterns
+    included, excluded = subject(testset, nil, 'toto.foo')
+    t.assert_equals(included, {testset[1]})
+    t.assert_equals(#excluded, 7)
+
+    -- --run-test-case with a matching pattern
+    included, excluded = subject(testset, {'toto'}, 'toto.foo')
+    t.assert_equals(included, {testset[1]})
+    t.assert_equals(#excluded, 7)
+
+    -- --run-test-case with a non-matching pattern
+    included, excluded = subject(testset, {'tutu'}, 'toto.foo')
+    t.assert_equals(included, {})
+    t.assert_equals(#excluded, 8)
 end
 
 function g.test_str_match()


### PR DESCRIPTION
These options allow an external runner (such as [test-run][test-run]) to run the test cases separately: isolated and/or parallel.

The idea is the following.

* test-run has some criteria, whether to parallelize the given test.
* If it needs to be parallelized, test-run invokes `luatest --list-test-cases <..path to test..>`.
* Then each test case is run in its own process using `luatest --run-test-case <..test case..> <..path to test..>`.

The `--run-test-case` option may be simulated using `--pattern`, but it requires regexp escaping. It is more convenient to have a separate option to pass a verbatim test case name.

The new CLI options are mostly for scripting and not for interactive use. So, no short option are added for them.

[test-run]: https://github.com/tarantool/test-run
