### PR TITLE
test: don't fail if luatest is in system paths

### DIFF
--- a/test/autorequire_luatest_test.lua
+++ b/test/autorequire_luatest_test.lua
@@ -75,12 +75,15 @@ g.test_exec_with_upvalue_and_local_variable = function()
 end
 
 g.before_test('test_exec_when_luatest_not_found', function()
-    -- Setup custom server without LUA_PATH variable
+    -- Setup custom server without luatest in LUA_PATH.
     g.bad_env_server = Server:new({
         command = command,
         workdir = fio.tempdir(),
         http_port = 8183,
         net_box_port = 3134,
+        env = {
+            LUA_PATH = '',
+        },
     })
 
     fio.mktree(g.bad_env_server.workdir)


### PR DESCRIPTION
`test_exec_when_luatest_not_found` fails if `luatest` is installed into `/usr/share/tarantool`.

Zap `LUA_PATH` to ensure that `require('luatest')` reports the 'module not found' error.
