### PR TITLE
Adapt the server to use the declarative config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add `--list-test-cases` and `--run-test-case` CLI options.
 - Introduce preloaded hooks (gh-380).
 - Add `treegen` helper as a tree generator (gh-364).
+- Add support for declarative configuration to `server.lua` (gh-367).
 
 ## 1.0.1
 

--- a/luatest/utils.lua
+++ b/luatest/utils.lua
@@ -1,4 +1,5 @@
 local digest = require('digest')
+local fio = require('fio')
 local fun = require('fun')
 local yaml = require('yaml')
 
@@ -194,6 +195,27 @@ end
 -- Return args as table with 'n' set to args number.
 function utils.table_pack(...)
     return {n = select('#', ...), ...}
+end
+
+-- Join paths in an intuitive way.
+-- If a component is nil, it is skipped.
+-- If a component is an absolute path, it skips all the previous
+-- components.
+-- The wrapper is written for two components for simplicity.
+function utils.pathjoin(a, b)
+    -- No first path -- skip it.
+    if a == nil then
+        return b
+    end
+    -- No second path -- skip it.
+    if b == nil then
+        return a
+    end
+    -- The absolute path is checked explicitly due to gh-8816.
+    if b:startswith('/') then
+        return b
+    end
+    return fio.pathjoin(a, b)
 end
 
 return utils


### PR DESCRIPTION
You can use a declarative config file to configure a server instance via the following options:

  - config_file (optional) Declarative YAML configuration for a server
    instance. Used to deduce advertise URI to connect `net.box` to the
    instance. The special value '' means running without `--config ...`
    CLI option (but still passes `--name <alias>`).

  - remote_config (optional) If `config_file` is not passed, this config
    value is used to deduce the advertise URI to connect `net.box` to
    the instance.

Close #367