### PR TITLE
Create luatest.log file in VARDIR

### DIFF
--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -61,6 +61,9 @@ function Runner.run(args, options)
         local log_prefix = options.log_prefix or 'luatest'
         local log_cfg = string.format("%s.log", log_prefix)
 
+        fio.mktree(Server.vardir)
+        log_cfg = fio.pathjoin(Server.vardir, log_cfg)
+
         if options.log_file then
             -- Save the file descriptor as a global variable to use it
             -- in the `output_beautifier` module: this module is connected to the


### PR DESCRIPTION
Currently, it's created in the current directory, which is annoying.

Not adding a change log because this issues fixes commit f8a1c10baa482, which hasn't been released yet.

Closes #373