### PR TITLE
Add a long option --no-capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add `treegen` helper as a tree generator (gh-364).
 - Add support for declarative configuration to `server.lua` (gh-367).
 - Make `assert_covers` recursive (gh-379).
+- Add alias `--no-capture` for the option `-c` (gh-391).
 
 ## 1.0.1
 

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -138,7 +138,7 @@ Options:
   -vv,                    Increase log verbosity to VERBOSE level for luatest runnner
   -vvv,                   Increase log verbosity to DEBUG level for luatest runnner
   -q, --quiet:            Set verbosity to minimum
-  -c                      Disable capture
+  -c, --no-capture        Disable capture
   -b                      Print full backtrace (don't remove luatest frames)
   -e, --error:            Stop on first error
   -f, --failure:          Stop on first failure or error
@@ -236,7 +236,7 @@ function Runner.parse_cmd_line(args)
             table.insert(result.tests_pattern, '!' .. next_arg())
         elseif arg == '-b' then
             result.full_backtrace = true
-        elseif arg == '-c' then
+        elseif arg == '--no-capture' or arg == '-c' then
             result.enable_capture = false
         elseif arg == '--coverage' then
             result.coverage_report = true


### PR DESCRIPTION
The option `-c` allows to disable capture and this option has no long variant with self-explained name.
The patch fixes that.

Closes #391