### PR TITLE
server: fix assertion error serialization in exec()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Add support for declarative configuration to `server.lua` (gh-367).
 - Make `assert_covers` recursive (gh-379).
 - Add alias `--no-capture` for the option `-c` (gh-391).
+- Fix reporting of an assertion failure in `Server:exec()` in case verbose
+  error serialization is enabled in Tarantool (gh-376).
 
 ## 1.0.1
 


### PR DESCRIPTION
Commit e6a209378038 ("Add error handling at the server instance") broke assertion failure reporting in `server:exec()` in case verbose error serialization is enabled in Tarantool (`box_error_serialize_verbose` compatibility option is set to `new`).

The problem is with the verbose error serialization, a raw string raised with `error()` is converted to an error object when marshalled through IPROTO while the `server:exec()` code expects it to remain a string because it encodes the original error in JSON. As a result, we get a mangled error like

```
{"status":"fail","class":"LuatestError","message":"...some_test.lua:42: expected: a value evaluating to true, actual: false"} {"code":32,"type":"LuajitError","trace":[{"file":"./src/lua/utils.c","line":687}]}
```

instead of

```
...some_test.lua:42: expected: a value evaluating to true, actual: false
```

To fix this issue, we revert the JSON encoding hack introduced by the aforementioned commit. In order not to reintroduce issue #242 fixed by that commit, we simply rollback the active transaction (if any) in case the executed function failed.

Closes #376