### PR TITLE
Propagate stack trace from Server:exec()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix reporting of an assertion failure in `Server:exec()` in case verbose
   error serialization is enabled in Tarantool (gh-376).
 - Added `assert_items_exclude`.
+- Strip useless `...` lines from error trace.
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   error serialization is enabled in Tarantool (gh-376).
 - Added `assert_items_exclude`.
 - Strip useless `...` lines from error trace.
+- Fix error trace reporting for functions executed with `Server:exec()`
+  (gh-396).
 
 ## 1.0.1
 

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -474,6 +474,16 @@ function Runner.mt:protected_call(instance, method, pretty_name)
     end, function(e)
         -- transform error into a table, adding the traceback information
         local trace = debug.traceback('', 3):sub(2)
+        if type(e) == 'table' and e.class == 'LuatestErrorWrapper' then
+            -- This is an error wrapped by Server:exec() to save the trace.
+            -- Concatenate the current trace with the saved trace and restore
+            -- the original error.
+            assert(e.trace ~= nil)
+            assert(e.error ~= nil)
+            trace = e.trace .. '\n' ..
+                    trace:sub(string.len('stack traceback:\n') + 1)
+            e = e.error
+        end
         if utils.is_luatest_error(e) then
             return {status = e.status, message = e.message, trace = trace}
         else

--- a/test/fixtures/trace.lua
+++ b/test/fixtures/trace.lua
@@ -1,0 +1,47 @@
+local fio = require('fio')
+
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('fixtures.trace')
+
+local root = fio.dirname(fio.abspath('test.helpers'))
+
+g.before_all(function(cg)
+    cg.server = server:new{
+        env = {
+            LUA_PATH = root .. '/?.lua;' ..
+                root .. '/?/init.lua;' ..
+                root .. '/.rocks/share/tarantool/?.lua'
+        }
+    }
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_error = function(cg)
+    local function outer()
+        cg.server:exec(function()
+            local function inner()
+                error('test error')
+            end
+            inner()
+        end)
+    end
+    outer()
+end
+
+g.test_fail = function(cg)
+    local function outer()
+        cg.server:exec(function()
+            local function inner()
+                t.assert(false)
+            end
+            inner()
+        end)
+    end
+    outer()
+end

--- a/test/luaunit/utility_test.lua
+++ b/test/luaunit/utility_test.lua
@@ -847,6 +847,43 @@ function g.test_stripStackTrace()
         [[stack traceback:
     luaunit2/example_with_luaunit.lua:124: in function 'test1_withFailure']]
     )
+
+    t.assert_equals(subject([[stack traceback:
+    /tmp/luatest/luatest/utils.lua:55: in function 'luatest_error'
+    /tmp/luatest/luatest/assertions.lua:66: in function 'failure'
+    /tmp/luatest/luatest/assertions.lua:71: in function 'fail_fmt'
+    /tmp/luatest/luatest/assertions.lua:341: in function 'assert_le'
+    /tmp/luatest/test/example_test.lua:37: in function 'check'
+    /tmp/luatest/test/example_test.lua:40: in function </tmp/luatest/test/example_test.lua:34>
+    [C]: in function 'xpcall'
+    eval:9: in main chunk
+    [C]: at 0x5da8d110ced6
+    /tmp/luatest/luatest/server.lua:745: in function 'exec'
+    /tmp/luatest/test/example_test.lua:34: in function 'test.test_fail_server'
+    /tmp/luatest/luatest/runner.lua:472: in function </tmp/luatest/luatest/runner.lua:471>
+    [C]: in function 'xpcall'
+    /tmp/luatest/luatest/runner.lua:471: in function 'super'
+    /tmp/luatest/luatest/capturing.lua:106: in function 'protected_call'
+    /tmp/luatest/luatest/runner.lua:559: in function 'super'
+    /tmp/luatest/luatest/hooks.lua:290: in function 'invoke_test_function'
+    /tmp/luatest/luatest/runner.lua:554: in function 'super'
+    ...
+    [C]: in function 'xpcall'
+    /tmp/luatest/luatest/utils.lua:39: in function 'run_tests'
+    /tmp/luatest/luatest/runner.lua:381: in function </tmp/luatest/luatest/runner.lua:366>
+    [C]: in function 'xpcall'
+    /tmp/luatest/luatest/capturing.lua:74: in function </tmp/luatest/luatest/capturing.lua:72>
+    [C]: in function 'xpcall'
+    /tmp/luatest/luatest/runner.lua:55: in function 'fn'
+    .../vlad/src/tarantool/luatest/luatest/sandboxed_runner.lua:14: in function 'run'
+    /tmp/luatest/luatest/cli_entrypoint.lua:4: in function </tmp/luatest/luatest/cli_entrypoint.lua:3>
+    /tmp/luatest/bin/luatest:5: in main chunk]]
+        ),
+        [[stack traceback:
+    /tmp/luatest/test/example_test.lua:37: in function 'check'
+    /tmp/luatest/test/example_test.lua:40: in function </tmp/luatest/test/example_test.lua:34>
+    /tmp/luatest/test/example_test.lua:34: in function 'test.test_fail_server']]
+    )
 end
 
 function g.test_eps_value()

--- a/test/runner_test.lua
+++ b/test/runner_test.lua
@@ -224,3 +224,30 @@ g.test_show_help = function()
     local captured = capture:flush()
     t.assert_str_contains(captured.stdout, 'Usage: luatest')
 end
+
+g.test_trace = function()
+    local f = io.popen('bin/luatest test/fixtures/trace.lua')
+    local output = f:read('*a')
+    f:close()
+    t.assert_str_matches(
+        output,
+        ".*" ..
+        "[^\n]*trace%.lua:29: test error[^\n]*\n" ..
+        "stack traceback:\n" ..
+        "[^\n]*trace%.lua:29: in function 'inner'\n" ..
+        "[^\n]*trace%.lua:31: in function <[^\n]*trace%.lua:27>\n" ..
+        "[^\n]*trace%.lua:27: in function 'outer'\n" ..
+        "[^\n]*trace%.lua:34: in function 'fixtures%.trace%.test_error'\n" ..
+        ".*")
+    t.assert_str_matches(
+        output,
+        ".*" ..
+        "[^\n]*trace%.lua:41: expected: a value evaluating to true, " ..
+            "actual: false[^\n]*\n" ..
+        "stack traceback:\n" ..
+        "[^\n]*trace%.lua:41: in function 'inner'\n" ..
+        "[^\n]*trace%.lua:43: in function <[^\n]*trace%.lua:39>\n" ..
+        "[^\n]*trace%.lua:39: in function 'outer'\n" ..
+        "[^\n]*trace%.lua:46: in function 'fixtures%.trace%.test_fail'\n" ..
+        ".*")
+end


### PR DESCRIPTION
If a function executed with `Server:exec()` fails, luatest prints the stack trace only up to the `Server:exec()` call. If the failure happens to be in a nested function, this makes it impossible to figure out what happened.

Let's propagate the error stack trace from the server to the runner and make the runner concatenate it with its own stack trace. To achieve that, we wrap errors raised by the function executed by `Serer:exec()` to save the trace.

Closes #396