### PR TITLE
Support for JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Fix error trace reporting for functions executed with `Server:exec()`
   (gh-396).
 
+## 1.0.2
+- Support for json output
+
 ## 1.0.1
 
 - Fixed incorrect Unix domain socket path length check (gh-341).

--- a/luatest/output/json.lua
+++ b/luatest/output/json.lua
@@ -1,0 +1,57 @@
+local json = require('json')
+local Output = require('luatest.output.generic'):new_class()
+
+local res = {}
+
+function Output.mt:start_suite()
+    res = {
+        started_on = self.result.start_time,
+        tests = {},
+    }
+end
+
+function Output.mt:end_test(node)
+    local test = {
+        name = node.name,
+        message = node.message,
+        group = node.group.name,
+    }
+
+    if node:is('xfail') then
+        test.xfail = true
+    end
+
+    if node:is('skip') then
+        test.skip = true
+    end
+
+    if node:is('success') then
+        test.status = 'OK'
+    end
+
+    if node:is('fail')then
+        test.status = 'FAIL'
+    end
+
+    if node:is('error')then
+        test.status = 'ERROR'
+    end
+
+    table.insert(res.tests, test)
+end
+
+function Output.mt:end_suite()
+    local tests = self.result.tests
+    res.xfail = #tests.xfail
+    res.xsuccess = #tests.xsuccess
+    res.fail = #tests.fail
+    res.error = #tests.error
+    res.skip = #tests.skip
+    res.all = #tests.all
+    res.success = #tests.success
+    res.duration = self.result.duration
+
+    print(json.encode(res))
+end
+
+return Output

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -46,7 +46,7 @@ Runner.mt.tests_path = 'test'
 -- @func[opt] options.load_tests Function to load tests. Called once for every item in `paths`.
 -- @string[opt='none'] options.shuffle Shuffle method (none, all, group)
 -- @int[opt] options.seed Random seed for shuffle
--- @string[opt='text'] options.output Output formatter (text, tap, junit, nil)
+-- @string[opt='text'] options.output Output formatter (text, tap, junit, json, nil)
 function Runner.run(args, options)
     args = args or rawget(_G, 'arg')
     options = options or {}
@@ -151,7 +151,7 @@ Options:
                             - none - sort tests within group by line number (default)
   --seed NUMBER:          Set seed value for shuffler
   -o, --output OUTPUT:    Set output type to OUTPUT
-                          Possible values: text, tap, junit, nil
+                          Possible values: text, tap, junit, json, nil
   -n, --name NAME:        For junit only, mandatory name of xml file
   -r, --repeat NUM:       Execute all tests NUM times, e.g. to trig the JIT
   -R, --repeat-group NUM: Execute all groups of tests NUM times, e.g. to trig the JIT

--- a/test/output_test.lua
+++ b/test/output_test.lua
@@ -57,6 +57,7 @@ local output_presets = {
     tap = {'-o', 'tap'},
     tap_verbose = {'-o', 'tap', '-v'},
     ['nil'] = {'-o', 'nil'},
+    json = {'-o', 'json'},
 }
 
 for output_type, options in pairs(output_presets) do


### PR DESCRIPTION
Added support for JSON output. The goal is to simplify the parsing of test results by external systems such as https://github.com/mivallion/vscode-tarantool-luatest-adapter

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

