### PR TITLE
Fix cluster and cbuilder module doc formatting

### DIFF
--- a/luatest/cbuilder.lua
+++ b/luatest/cbuilder.lua
@@ -17,8 +17,8 @@
 --     :add_instance('instance-003', {})
 --     :config()
 --
--- By default, all instances are added to replicaset-001 in group-001,
--- but it's possible to select a different replicaset and/or group:
+-- -- By default, all instances are added to replicaset-001 in group-001,
+-- -- but it's possible to select a different replicaset and/or group:
 --
 -- local config = Builder:new()
 --     :use_group('group-001')
@@ -35,14 +35,13 @@
 --
 --     :config()
 --
--- The default credentials and iproto options are added to
--- setup replication and to allow a test to connect to the
--- instances.
+-- -- The default credentials and iproto options are added to
+-- -- setup replication and to allow a test to connect to the
+-- -- instances.
 --
--- There is a few other methods:
---
--- * :set_replicaset_option('foo.bar', value)
--- * :set_instance_option('instance-001', 'foo.bar', value)
+-- -- There is a few other methods:
+-- -- * :set_replicaset_option('foo.bar', value)
+-- -- * :set_instance_option('instance-001', 'foo.bar', value)
 --
 -- @classmod luatest.cbuilder
 

--- a/luatest/cluster.lua
+++ b/luatest/cluster.lua
@@ -13,25 +13,24 @@
 --     server:exec(<...>)
 -- end)
 --
--- After setting up a cluster object the following methods could
--- be used to interact with it:
+-- -- After setting up a cluster object the following methods
+-- -- could be used to interact with it:
+-- -- * :start() Startup the cluster.
+-- -- * :start_instance() Startup a specific instance.
+-- -- * :stop() Stop the cluster.
+-- -- * :each() Execute a function on each instance.
+-- -- * :size() get an amount of instances
+-- -- * :drop() Drop the cluster.
+-- -- * :sync() Sync the configuration and collect a new set of
+-- -- instances
+-- -- * :reload() Reload the configuration.
 --
--- * :start() Startup the cluster.
--- * :start_instance() Startup a specific instance.
--- * :stop() Stop the cluster.
--- * :each() Execute a function on each instance.
--- * :size() get an amount of instances
--- * :drop() Drop the cluster.
--- * :sync() Sync the configuration and collect a new set of
---   instances
--- * :reload() Reload the configuration.
+-- -- The module can also be used for testing failure startup
+-- -- cases:
 --
--- The module can also be used for testing failure startup
--- cases:
+-- Cluster.startup_error(config, "something went wrong")
 --
--- Cluster:startup_error(config, error_message)
---
--- @module luatest.cluster
+-- @classmod luatest.cluster
 
 local fun = require('fun')
 local yaml = require('yaml')


### PR DESCRIPTION
This patchset fixes a few problems in cbuilder and cluster module documentation formatting.

The first patch fixes a few errors in cluster module documentation:
* The module is now classified as a class module instead of a regular module.
* Added missing `--` denoting Lua comments in the usage section.
* Changed abstract `exp_err` in `cluster.startup_error` to a specific error.

The second patch fixes a few errors in cbuilder module documentation by adding missing `--` denoting Lua comments in the usage section.

