### PR TITLE
Run tests and packaging on ubuntu-latest

### DIFF
--- a/.github/workflows/package_test.yml
+++ b/.github/workflows/package_test.yml
@@ -19,7 +19,7 @@ jobs:
           - dist: fedora
             version: 36
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out repo

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         tarantool: ["1.10", "2.6", "2.7", "2.8", "2.10", "2.11", "3.0"]
       fail-fast: false
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@master
       - uses: tarantool/setup-tarantool@v3


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported by GitHub runners.