### PR TITLE
cluster: expel instances removed from config in cluster.sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fixed a bug when `server:grep_log()` failed to find a string logged in
   `server:exec()` called immediately before it (gh-421).
+- Fixed a bug when it wasn't possible to reload the cluster config with
+  `cluster:reload()` after removing an instance with `cluster:sync()`.
+  Also added an option to `cluster:sync()` to start/stop added/removed
+  instances (gh-423).
 
 ## 1.1.0
 


### PR DESCRIPTION
Currently, `cluster:sync()` leaves instances removed from the config in the instance list. This makes `cluster:reload()` fail because it tries to reload the config for all instances including those that are not in the config anymore. To fix that, let's make `cluster:sync()` move instances that were removed from the config to the special expelled instance list so that they become inaccessible via cluster but are still dropped by `cluster:drop()`.

Also, let's add the new boolean option `start_stop` for `cluster:sync()`. If set, `cluster:sync()` will stop old servers and start new ones.

Closes #423