### PR TITLE
server: fix opts.reset handling in grep_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug when `Server:grep_log()` didn't consider the `reset` option.
+
 ## 1.2.0
 
 - Fixed a bug when `server:grep_log()` failed to find a string logged in

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -878,7 +878,10 @@ end
 -- @return string|nil
 function Server:grep_log(pattern, bytes_num, opts)
     local options = opts or {}
-    local reset = options.reset or true
+    local reset = options.reset
+    if reset == nil then
+        reset = true
+    end
     local filename = options.filename or self.log_file
     local file = fio.open(filename, {'O_RDONLY', 'O_NONBLOCK'})
 

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -564,6 +564,9 @@ g.test_grep_log = function()
     server:connect_net_box()
     t.assert_not(server:grep_log('test grep_log'))
 
+    -- Test that opts.reset = false works.
+    t.assert(server:grep_log('test grep_log', nil, {reset = false}))
+
     server.net_box:close()
     server.net_box = nil
 end


### PR DESCRIPTION
Before this commit `opt.reset` wasn't working, because it was rewritten with true.