### PR TITLE
server: check if box.rollback is available in exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug when an error thrown by a function executed with `server:exec()`
+  in a Tarantool application thread was lost (gh-447).
+
 ## 1.4.0
 
 - Added a simple line-by-line diff to `t.assert_equals()` and `t.assert_covers()`

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -845,7 +845,7 @@ function Server:exec(fn, args, options)
                 trace = debug.traceback('', 3):sub(2),
             }
         end)}
-        if not result[1] then
+        if not result[1] and box.rollback ~= nil then
             box.rollback()
         end
         return unpack(result, 1, table.maxn(result))

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -737,3 +737,19 @@ g.test_do_not_save_server_artifacts_when_test_succeeded = function()
     t.assert_equals(result, 0)
     t.assert_not(fio.path.exists(log_path))
 end
+
+g.test_error_in_app_thread = function()
+    t.skip_if(not utils.version_current_ge_than(3, 7, 0),
+              'Application threads appeared in Tarantool 3.7.0.')
+
+    local s = Server:new({
+        box_cfg = {app_threads = 1},
+    })
+    s:start()
+
+    t.assert_error_msg_contains(
+        "My error", s.exec, s,
+        function() error("My error") end, {}, {_thread_id = 1})
+
+    s:drop()
+end


### PR DESCRIPTION
`server:exec()` calls `box.rollback()` on failure to avoid `ACTIVE_TRANSACTION` error in case the executed function fails in a transaction. The problem is that `box.rollback()` is unavailable in application threads so an attempt to call it results in the loss of the original error and throwing the following error instead:

```
eval:23: attempt to call field 'rollback' (a nil value)
```

Let's fix it by checking if `box.rollback()` is present before calling it.

Closes #447