### PR TITLE
server: set package.searchroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug when a test Tarantool server could not find Lua modules installed
+  from rocks in the current test directory or its ascendants.
+  To avoid compatibility issues with the old behavior, the `setsearchroot`
+  server option was added (gh-450).
+
 ## 1.4.1
 
 - Fixed a bug when an error thrown by a function executed with `server:exec()`

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -51,6 +51,8 @@ local Server = {
         alias = '?string',
 
         coverage_report = '?boolean',
+
+        setsearchroot = '?boolean',
     },
 }
 
@@ -103,6 +105,8 @@ end
 --   (but still passes `--name <alias>`).
 -- @tab[opt] object.remote_config If `config_file` is not passed, this config
 --   value is used to deduce advertise URI to connect net.box to the instance.
+-- @tab[opt] object.setsearchroot Set `package.searchroot` to be the same as
+--   in the Tarantool that starts the server.
 -- @tab[opt] extra Table with extra properties for the server object.
 -- @return table
 function Server:new(object, extra)
@@ -422,6 +426,16 @@ function Server:start(opts)
         -- instead of just `/path/to/script.lua`.
         table.insert(args, 1, command)
         command = arg[-1]
+    end
+
+    -- To fix the issue with rock-modules missing from the created instances,
+    -- we need to set `package.searchroot`. Furthermore, this must be done
+    -- before loading `command`. This is done if the `setsearchroot` option
+    -- is true or missing.
+    if self.setsearchroot == nil or self.setsearchroot then
+        table.insert(args, 1, '-e')
+        table.insert(args, 2,
+            string.format("package.setsearchroot('%s')", package.searchroot()))
     end
 
     local log_cmd = {}

--- a/test/autorequire_luatest_test.lua
+++ b/test/autorequire_luatest_test.lua
@@ -14,11 +14,6 @@ g.before_all(function()
     g.server = Server:new({
         command = command,
         workdir = fio.pathjoin(datadir, 'common'),
-        env = {
-            LUA_PATH = root .. '/?.lua;' ..
-                root .. '/?/init.lua;' ..
-                root .. '/.rocks/share/tarantool/?.lua'
-        },
         http_port = 8182,
         net_box_port = 3133,
     })
@@ -84,6 +79,7 @@ g.before_test('test_exec_when_luatest_not_found', function()
         env = {
             LUA_PATH = '',
         },
+        setsearchroot = false,
     })
 
     fio.mktree(g.bad_env_server.workdir)

--- a/test/cluster_test.lua
+++ b/test/cluster_test.lua
@@ -2,22 +2,8 @@ local t = require('luatest')
 local cbuilder = require('luatest.cbuilder')
 local cluster = require('luatest.cluster')
 local utils = require('luatest.utils')
-local fio = require('fio')
 
 local g = t.group()
-
-local root = fio.dirname(fio.abspath('test.helpers'))
-
--- These are extra server opts passed to the cluster.
--- They are needed for the server to be able to access
--- luatest.coverage.
-local server_opts = {
-    env = {
-        LUA_PATH = root .. '/?.lua;' ..
-            root .. '/?/init.lua;' ..
-            root .. '/.rocks/share/tarantool/?.lua',
-    }
-}
 
 local function assert_instance_running(c, instance, replicaset)
     local server = c[instance]
@@ -66,7 +52,7 @@ g.test_start_stop = function()
 
         :config()
 
-    local c = cluster:new(config, server_opts)
+    local c = cluster:new(config)
     c:start()
 
     assert_instance_running(c, 'instance-x1', 'replicaset-x')
@@ -107,7 +93,7 @@ g.test_start_instance = function()
 
         :config()
 
-    local c = cluster:new(config, server_opts)
+    local c = cluster:new(config)
 
     t.assert_equals(c:size(), 3)
     c:start_instance('i-002')
@@ -133,7 +119,7 @@ g.test_manual_lifecycle = function()
         :add_instance('cluster-1', {})
         :config()
 
-    local c1 = cluster:new(config, server_opts, {auto_cleanup = false})
+    local c1 = cluster:new(config, nil, {auto_cleanup = false})
 
     t.assert_equals(g._cluster, nil)
 
@@ -141,7 +127,7 @@ g.test_manual_lifecycle = function()
     assert_instance_running(c1, 'cluster-1')
     c1:drop()
 
-    local c2 = cluster:new(config, server_opts, {auto_cleanup = false})
+    local c2 = cluster:new(config, nil, {auto_cleanup = false})
 
     t.assert_equals(g._cluster, nil)
 
@@ -163,7 +149,7 @@ g.test_sync = function()
         :add_instance('i-001', {})
         :config()
 
-    local c = cluster:new(config, server_opts)
+    local c = cluster:new(config)
 
     t.assert_equals(c:size(), 1)
 
@@ -226,7 +212,7 @@ g.test_sync_start_stop = function()
         :add_instance('i-001', {})
         :config()
 
-    local c = cluster:new(config, server_opts)
+    local c = cluster:new(config)
 
     t.assert_equals(c:size(), 1)
 
@@ -288,7 +274,7 @@ g.test_reload = function()
 
         :config()
 
-    local c = cluster:new(config, server_opts)
+    local c = cluster:new(config)
     c:start()
 
     assert_instance_failover_mode(c, 'i-001', 'election')
@@ -319,7 +305,7 @@ g.test_modify_config = function()
         :add_instance('i-001', {})
         :config()
 
-    local c = cluster:new(config, server_opts)
+    local c = cluster:new(config)
 
     c:start()
 
@@ -383,7 +369,7 @@ g.test_each = function()
 
         :config()
 
-    local c = cluster:new(config, server_opts)
+    local c = cluster:new(config)
 
     local res = {}
     c:each(function(server)
@@ -427,7 +413,7 @@ g_persistent_clusters.before_all(function()
             :add_instance(instance, {})
             :config()
 
-        local c = cluster:new(config, server_opts, {auto_cleanup = false})
+        local c = cluster:new(config, nil, {auto_cleanup = false})
         c:start()
         assert_instance_running(c, instance)
 

--- a/test/fixtures/trace.lua
+++ b/test/fixtures/trace.lua
@@ -1,20 +1,10 @@
-local fio = require('fio')
-
 local t = require('luatest')
 local server = require('luatest.server')
 
 local g = t.group('fixtures.trace')
 
-local root = fio.dirname(fio.abspath('test.helpers'))
-
 g.before_all(function(cg)
-    cg.server = server:new{
-        env = {
-            LUA_PATH = root .. '/?.lua;' ..
-                root .. '/?/init.lua;' ..
-                root .. '/.rocks/share/tarantool/?.lua'
-        }
-    }
+    cg.server = server:new()
     cg.server:start()
 end)
 

--- a/test/runner_test.lua
+++ b/test/runner_test.lua
@@ -232,22 +232,22 @@ g.test_trace = function()
     t.assert_str_matches(
         output,
         ".*" ..
-        "[^\n]*trace%.lua:29: test error[^\n]*\n" ..
+        "[^\n]*trace%.lua:19: test error[^\n]*\n" ..
         "stack traceback:\n" ..
-        "[^\n]*trace%.lua:29: in function 'inner'\n" ..
-        "[^\n]*trace%.lua:31: in function <[^\n]*trace%.lua:27>\n" ..
-        "[^\n]*trace%.lua:27: in function 'outer'\n" ..
-        "[^\n]*trace%.lua:34: in function 'fixtures%.trace%.test_error'\n" ..
+        "[^\n]*trace%.lua:19: in function 'inner'\n" ..
+        "[^\n]*trace%.lua:21: in function <[^\n]*trace%.lua:17>\n" ..
+        "[^\n]*trace%.lua:17: in function 'outer'\n" ..
+        "[^\n]*trace%.lua:24: in function 'fixtures%.trace%.test_error'\n" ..
         ".*")
     t.assert_str_matches(
         output,
         ".*" ..
-        "[^\n]*trace%.lua:41: expected: a value evaluating to true, " ..
+        "[^\n]*trace%.lua:31: expected: a value evaluating to true, " ..
             "actual: false[^\n]*\n" ..
         "stack traceback:\n" ..
-        "[^\n]*trace%.lua:41: in function 'inner'\n" ..
-        "[^\n]*trace%.lua:43: in function <[^\n]*trace%.lua:39>\n" ..
-        "[^\n]*trace%.lua:39: in function 'outer'\n" ..
-        "[^\n]*trace%.lua:46: in function 'fixtures%.trace%.test_fail'\n" ..
+        "[^\n]*trace%.lua:31: in function 'inner'\n" ..
+        "[^\n]*trace%.lua:33: in function <[^\n]*trace%.lua:29>\n" ..
+        "[^\n]*trace%.lua:29: in function 'outer'\n" ..
+        "[^\n]*trace%.lua:36: in function 'fixtures%.trace%.test_fail'\n" ..
         ".*")
 end

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -20,9 +20,6 @@ local server = Server:new({
     command = command,
     workdir = fio.pathjoin(datadir, 'common'),
     env = {
-        LUA_PATH = root .. '/?.lua;' ..
-            root .. '/?/init.lua;' ..
-            root .. '/.rocks/share/tarantool/?.lua',
         custom_env = 'test_value',
     },
     http_port = 8182,


### PR DESCRIPTION
This patch sets the `package.searchroot` value for a newly created server to the same value as in the Tarantool that created the server.

Closes #450