### PR TITLE
Forbid using with Tarantool < 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Explicitly forbid using Luatest with Tarantool < 2.2.1 (gh-453).
+
 ## 1.4.2
 
 - Fixed a bug when a test Tarantool server could not find Lua modules installed

--- a/luatest/init.lua
+++ b/luatest/init.lua
@@ -2,6 +2,11 @@
 -- @module luatest
 local luatest = setmetatable({}, {__index = require('luatest.assertions')})
 
+local utils = require('luatest.utils')
+if not utils.version_current_ge_than(2, 2, 1) then
+    error('Luatest supports only Tarantool >= 2.2.1')
+end
+
 luatest.Process = require('luatest.process')
 luatest.VERSION = require('luatest.VERSION')
 


### PR DESCRIPTION
Tarantool 1.10 cannot be used with Luatest anymore due to tarantoool/luatest@bffdd7d. Any test fails, since Tarantool 1.10 doesn't have `package.searchroot` defined.

Let's won't break backward compatibility, when it costs us nothing. For that we set the `searchroot` argument iff `package.searchroot` is defined.

Closes #453