### PR TITLE
server: create net.box credentials user for default instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 - Explicitly forbid using Luatest with Tarantool < 2.2.1 (gh-453).
+- Fixed a bug when `Server.net_box_credentials` could not be used with
+  the default server instance unless the specified user already existed.
+  Now the specified user is created and granted the 'super' role at startup
+  if it doesn't exist (gh-456).
 
 ## 1.4.2
 

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -96,7 +96,9 @@ end
 --   into the server process. If it is a Unix socket, the corresponding socket
 --   directory path will be created on the server start.
 -- @tab[opt] object.net_box_credentials Override the default credentials for the
---   `net.box` connection to the new server.
+--   `net.box` connection to the new server and the value of the
+--   `TARANTOOL_CREDENTIALS` env variable which is passed into the server
+--   process.
 -- @tab[opt] object.box_cfg Extra options for `box.cfg()` and the value of the
 --   `TARANTOOL_BOX_CFG` env variable which is passed into the server process.
 -- @string[opt] object.config_file Declarative YAML configuration for a server
@@ -355,6 +357,9 @@ function Server:build_env()
     }
     if self.box_cfg ~= nil then
         res.TARANTOOL_BOX_CFG = json.encode(self.box_cfg)
+    end
+    if self.net_box_credentials ~= nil then
+        res.TARANTOOL_CREDENTIALS = json.encode(self.net_box_credentials)
     end
     return res
 end

--- a/luatest/server_instance.lua
+++ b/luatest/server_instance.lua
@@ -39,7 +39,31 @@ end
 
 box.cfg(box_cfg())
 
-box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists = true})
+local credentials = os.getenv('TARANTOOL_CREDENTIALS')
+if credentials ~= nil then
+    credentials = json.decode(credentials)
+    assert(type(credentials) == 'table')
+    assert(type(credentials.user) == 'string')
+    assert(credentials.password == nil or
+           type(credentials.password) == 'string')
+else
+    credentials = {user = 'guest'}
+end
+-- Users 'admin' and 'guest' are predefined.
+if credentials.user ~= 'admin' and credentials.user ~= 'guest' then
+    box.schema.user.create(credentials.user, {if_not_exists = true})
+end
+-- User 'admin' has all privileges so it does not need role 'super'.
+if credentials.user ~= 'admin' then
+    box.schema.user.grant(credentials.user, 'super', nil, nil,
+                          {if_not_exists = true})
+end
+-- User 'guest' doesn't require authentication.
+if credentials.user ~= 'guest' then
+    if next(box.space._user.index.name:get(credentials.user).auth) == nil then
+        box.schema.user.passwd(credentials.user, credentials.password or '')
+    end
+end
 
 -- server:wait_until_ready() unblocks only when this variable becomes `true`.
 -- In this case, it is considered that the instance is fully operable.

--- a/test/server_test.lua
+++ b/test/server_test.lua
@@ -750,3 +750,20 @@ g.test_error_in_app_thread = function()
 
     s:drop()
 end
+
+g.test_credentials = function()
+    local s = Server:new({
+        net_box_credentials = {user = 'admin'},
+    })
+    s:start()
+    s:exec(function()
+        t.assert_equals(box.session.user(), 'admin')
+    end)
+    s:restart({
+        net_box_credentials = {user = 'client', password = 'secret'},
+    })
+    s:exec(function()
+        t.assert_equals(box.session.user(), 'client')
+    end)
+    s:drop()
+end


### PR DESCRIPTION
Let's pass the value of `Server.net_box_credentials` to the server instance in the `TARANTOOL_CREDENTIALS` environment variable and make the default instance create the specified user unless it already exists. This will let us authenticate the net.box connection to a test server as any user, not just guest, which may be useful for tests that require admin privileges, for example, application thread tests.

Closes #456