### PR TITLE
justrun: set package.searchroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   the default server instance unless the specified user already existed.
   Now the specified user is created and granted the 'super' role at startup
   if it doesn't exist (gh-456).
+- The `justrun` module now also sets `searchroot` for the created
+  instance (gh-450).
 
 ## 1.4.2
 

--- a/luatest/justrun.lua
+++ b/luatest/justrun.lua
@@ -86,6 +86,11 @@ end
 --   Quote CLI arguments before concatenating them into a shell
 --   command.
 --
+-- - setsearchroot (boolean, default: true)
+--
+--   Set `package.searchroot` to be the same as in the Tarantool that starts
+--   the server.
+--
 -- @string dir Directory where the process will run.
 -- @tparam table env Environment variables for the process.
 -- @tparam table args Options that will be passed when the process starts.
@@ -101,6 +106,15 @@ function justrun.tarantool(dir, env, args, opts)
     -- influencing testing code.
     env['INPUTRC'] = '/dev/null'
 
+    -- To fix the issue with rock-modules missing from the created instances,
+    -- we need to set `package.searchroot`. Furthermore, this must be done
+    -- before all other args.
+    local setsearchroot_str = ''
+    if opts.setsearchroot == nil or opts.setsearchroot then
+        setsearchroot_str = string.format([[-e "package.setsearchroot('%s')"]],
+            package.searchroot())
+    end
+
     local tarantool_exe = arg[-1]
     -- Use popen.shell() instead of popen.new() due to lack of
     -- cwd option in popen (gh-5633).
@@ -110,8 +124,8 @@ function justrun.tarantool(dir, env, args, opts)
     local args_str = table.concat(fun.iter(args):map(function(v)
         return opts.quote_args and ('%q'):format(v) or v
     end):totable(), ' ')
-    local command = ('cd %s && %s %s %s'):format(dir, env_str, tarantool_exe,
-                                                 args_str)
+    local command = ('cd %s && %s %s %s %s'):format(dir, env_str, tarantool_exe,
+                                                    setsearchroot_str, args_str)
     log.info('Running a command: %s', command)
     local mode = opts.stderr and 'rR' or 'r'
     local ph = popen.shell(command, mode)


### PR DESCRIPTION
This patch sets `package.searchroot` for a Tarantool instance created with `justrun`. The set `searchroot` matches the one used by Tarantool that creates the instance. This is necessary to be able to find rock modules in the created instance that are accessible to the instance's creator.

Follow-up #450