### PR TITLE
server: scan log for asan errors on process termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug when errors reported by the address sanitizer during process
+  termination were ignored (gh-460).
+
 ## 1.4.3
 
 - Explicitly forbid using Luatest with Tarantool < 2.2.1 (gh-453).

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -586,15 +586,19 @@ function Server:stop()
         end
         local workdir = fio.basename(self.workdir)
         local pid = self.process.pid
-        -- Check the log file for crash and memory leak reports.
+        -- Check the log file for crash reports and sanitizer errors.
         if fio.path.exists(self.log_file) then
-            if self:grep_log('Segmentation fault$', math.huge) then
-                error(('Segmentation fault during process termination (alias: %s, workdir: %s, pid: %d)')
-                    :format(self.alias, workdir, pid))
-            end
-            if self:grep_log('LeakSanitizer: detected memory leaks$', math.huge) then
-                error(('Memory leak during process execution (alias: %s, workdir: %s, pid: %s)')
-                    :format(self.alias, workdir, pid))
+            for _, pattern in ipairs({
+                'Segmentation fault$',
+                'ERROR: AddressSanitizer: .*',
+                'ERROR: LeakSanitizer: .*',
+            }) do
+                local msg = self:grep_log(pattern, math.huge)
+                if msg then
+                    error(('Error during process termination ' ..
+                           '(alias: %s, workdir: %s, pid: %d)\n%s')
+                          :format(self.alias, workdir, pid, msg))
+                end
             end
         end
         log.info('Process of server %q (pid: %d) killed', self.alias, self.process.pid)


### PR DESCRIPTION
Currently, server logs are checked only for segmentation fault errors and memory leaks when the process is stopped. Let's check for address sanitizer errors as well.

Closes #460