### PR TITLE
Disable system checks by default in `cbuilder` base_config

### DIFF
--- a/luatest/cbuilder.lua
+++ b/luatest/cbuilder.lua
@@ -97,6 +97,16 @@ local base_config = {
         -- by half for my test.
         timeout = 0.1,
     },
+    -- Disable system checks by default in tests to avoid
+    -- environment-dependent alerts (THP, readahead, etc.).
+    conditional = {
+        {
+            ['if'] = 'tarantool_version >= 3.8.0',
+            config = {
+                checks = 'off',
+            },
+        },
+    },
 }
 
 function Builder:inherit(object)

--- a/test/cbuilder_test.lua
+++ b/test/cbuilder_test.lua
@@ -15,6 +15,14 @@ local DEFAULT_CONFIG = {
         listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
     },
     replication = {timeout = 0.1},
+    conditional = {
+        {
+            ['if'] = 'tarantool_version >= 3.8.0',
+            config = {
+                checks = 'off',
+            },
+        },
+    },
 }
 
 local function merge_config(base, diff)


### PR DESCRIPTION
This PR sets `config.checks` to `'off'` in `cbuilder.base_config` to avoid environment-dependent alerts (THP, readahead) in tests that use `cbuilder`.

Tests that need checks enabled should override `config.checks` explicitly.

Needed for tarantool/tarantool#12371.