### PR TITLE
server: scan logs for assertion failures on process termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug when assertion failures occurred during process termination
+  were ignored (gh-465).
+
 ## 1.4.4
 
 - Implemented verbose serialization of uncaught box errors thrown in tests

--- a/luatest/server.lua
+++ b/luatest/server.lua
@@ -592,6 +592,7 @@ function Server:stop()
                 'Segmentation fault$',
                 'ERROR: AddressSanitizer: .*',
                 'ERROR: LeakSanitizer: .*',
+                'tarantool: .*: Assertion `.*\' failed.$',
             }) do
                 local msg = self:grep_log(pattern, math.huge)
                 if msg then


### PR DESCRIPTION
If a server process fails with an assertion failure, the error will be silently ignored. Let's detect assertion failures like we detect segmentation faults and address sanitizer errors.

Closes #465