### PR TITLE
runner: initialize log after vardir cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed a bug when assertion failures occurred during process termination
   were ignored (gh-465).
+- Fixed a bug when the luatest log file was removed if the command line
+  option `--no-cleanup` was not used (gh-471).
 
 ## 1.4.4
 

--- a/luatest/log.lua
+++ b/luatest/log.lua
@@ -25,8 +25,6 @@ function log.initialize(options)
     local luatest_log_file = fio.pathjoin(vardir, luatest_log_prefix .. '.log')
     local unified_log_file = options.log_file
 
-    fio.mktree(vardir)
-
     if unified_log_file then
         -- Save the file descriptor as a global variable to use it in
         -- the `output_beautifier` module.

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -57,12 +57,6 @@ function Runner.run(args, options)
         end
         options = utils.merge(options.luatest.configure(), Runner.parse_cmd_line(args), options)
 
-        log.initialize({
-            vardir = Server.vardir,
-            log_file = options.log_file,
-            log_prefix = options.log_prefix,
-        })
-
         if options.help then
             print(Runner.USAGE)
             return 0
@@ -306,14 +300,18 @@ function Runner.mt:bootstrap()
     log.info('Bootstrap finished: %d test(s), %d group(s)', #self.paths, #self.groups)
 end
 
-function Runner.mt:cleanup()
+function Runner.mt:run()
     if not self.no_clean then
         fio.rmtree(Server.vardir)
-        log.info('Directory %s removed via cleanup procedure', Server.vardir)
     end
-end
+    fio.mktree(Server.vardir)
 
-function Runner.mt:run()
+    log.initialize({
+        vardir = Server.vardir,
+        log_file = self.log_file,
+        log_prefix = self.log_prefix,
+    })
+
     self:bootstrap()
     local filtered_list = self.class.filter_tests(self:find_tests(),
         self.tests_pattern, self.run_test_case)
@@ -327,7 +325,6 @@ function Runner.mt:run()
     end
 
     self:start_suite(#filtered_list[true], #filtered_list[false])
-    self:cleanup()
     self:run_tests(filtered_list[true])
     self:end_suite()
     if self.result.aborted then

--- a/test/fixtures/log.lua
+++ b/test/fixtures/log.lua
@@ -1,0 +1,10 @@
+local t = require('luatest')
+local g = t.group('fixtures.log')
+
+local fiber = require('fiber')
+
+g.test_log = function()
+    t.log('LUATEST LOG TEST')
+    -- XXX: workaround for #418 (logs are lost if tests don't yield)
+    fiber.sleep(0.5)
+end

--- a/test/runner_test.lua
+++ b/test/runner_test.lua
@@ -251,3 +251,13 @@ g.test_trace = function()
         "[^\n]*trace%.lua:36: in function 'fixtures%.trace%.test_fail'\n" ..
         ".*")
 end
+
+g.test_log = function()
+    local VARDIR = os.getenv('VARDIR') or '/tmp/t'
+    local LOG_PATH = fio.pathjoin(VARDIR, 'luatest.log')
+    t.assert_equals(run_file('log.lua'), 0)
+    local f = assert(io.open(LOG_PATH))
+    local s = f:read('*a')
+    f:close()
+    t.assert_str_contains(s, 'LUATEST LOG TEST')
+end


### PR DESCRIPTION
The luatest log file is created in the vardir (/tmp/t by default) before the vardir is cleaned up. As a result, the log file is lost unless the command line option `--no-cleanup` is used. Let's move the logger initialization after the vardir cleanup to fix that.

Closes #471