### PR TITLE
treegen: create temporary files in VARDIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   were ignored (gh-465).
 - Fixed a bug when the luatest log file was removed if the command line
   option `--no-cleanup` was not used (gh-471).
+- Now the `treegen` helper creates temporary files in `VARDIR`, which is
+  `/tmp/t` by default, so as not to pollute the system tmp directory.
 
 ## 1.4.4
 

--- a/luatest/runner.lua
+++ b/luatest/runner.lua
@@ -306,6 +306,10 @@ function Runner.mt:run()
     end
     fio.mktree(Server.vardir)
 
+    -- Set TMPDIR to make fio.tempdir() create temporary files in
+    -- the test directory so as not to pollute global /tmp.
+    os.setenv('TMPDIR', Server.vardir)
+
     log.initialize({
         vardir = Server.vardir,
         log_file = self.log_file,

--- a/test/luaunit/utility_test.lua
+++ b/test/luaunit/utility_test.lua
@@ -798,7 +798,7 @@ function g.test_junit_output_escape_for_attributes()
         })
 
         function g_positive_start_stages.test_start() end
-    end, {'-o', 'junit', '-n', output_path}), 0)
+    end, {'-o', 'junit', '-n', output_path, '--no-clean'}), 0)
 
     local file = assert(io.open(output_path .. '.xml'))
     local xml = file:read('*a')

--- a/test/treegen_test.lua
+++ b/test/treegen_test.lua
@@ -15,6 +15,9 @@ g.test_prepare_directory = function()
     treegen.add_template('^.*$', 'test_script')
     local dir = treegen.prepare_directory({'foo/bar.lua', 'baz.lua'})
 
+    local VARDIR = os.getenv('VARDIR') or '/tmp/t'
+    t.assert_equals(fio.dirname(dir), VARDIR)
+
     t.assert(fio.path.is_dir(dir))
     t.assert(fio.path.exists(dir))
 


### PR DESCRIPTION
The `treegen` module uses `fio.tempdir()` for creating temporary directories. The latter uses `/tmp` as the base directory. This is bad because if a test fails or the KEEP_DATA environment variable is set, temporary directories are not removed, thus polluting `/tmp`.

Let's override TMPDIR to VARDIR to force `fio.tempdir()` use VARDIR (`/tmp/t` by default) for creating temporary files.

Closes #467
